### PR TITLE
Fix division by 0 when grid is full

### DIFF
--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -210,7 +210,9 @@ class MapElitesRepertoire(flax.struct.PyTreeNode):
 
         random_key, sub_key = jax.random.split(random_key)
         grid_empty = self.fitnesses == -jnp.inf
-        p = (1.0 - grid_empty) / jnp.sum(grid_empty)
+
+        p = (1.0 - grid_empty)
+        p /= jnp.sum(p)
 
         samples = jax.tree_map(
             lambda x: jax.random.choice(sub_key, x, shape=(num_samples,), p=p),


### PR DESCRIPTION
Hi,

we noticed that when the grid was full, there was a division by 0 in the [sampling function of the repertoire](https://github.com/adaptive-intelligent-robotics/QDax/blob/55723ea63be1ac41991bb309cd3d3dba5f791e2f/qdax/core/containers/repertoire.py#L212-L213), which lead to inconsistencies when sampling individuals.

```python
        grid_empty = self.fitnesses == -jnp.inf
        p = (1.0 - grid_empty) / jnp.sum(grid_empty)
```

This pull request aims at solving that issue.

Best regards,