### PR TITLE
Add the algorithm OMG-MEGA to QDax

### DIFF
--- a/notebooks/omgmega_example.ipynb
+++ b/notebooks/omgmega_example.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Optimizing with OMG-MEGA in Jax\n",
+    "\n",
+    "This notebook shows how to use QDax to find diverse and performing parameters on the Rastrigin problem.\n",
+    "It can be run locally or on Google Colab. We recommand to use a GPU. This notebook will show:\n",
+    "- how to define the problem\n",
+    "- how to create an omg-mega emitter\n",
+    "- how to create a Map-elites instance\n",
+    "- which functions must be defined before training\n",
+    "- how to launch a certain number of training steps\n",
+    "- how to visualise the optimization process"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -37,7 +53,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set the hyperparameters"
+    "## Set the hyperparameters\n",
+    "\n",
+    "Most hyperparameters are similar to those introduced in [Differentiable Quality Diversity paper](https://arxiv.org/abs/2106.03894)."
    ]
   },
   {
@@ -52,10 +70,11 @@
     "num_dimensions = 1000 #@param {type:\"integer\"}\n",
     "num_centroids = 10000 #@param {type:\"integer\"}\n",
     "num_descriptors = 2 #@param {type:\"integer\"}\n",
-    "sigma_g=10\n",
+    "sigma_g=10 #@param {type:\"number\"}\n",
     "minval = -5.12 #@param {type:\"number\"}\n",
     "maxval = 5.12 #@param {type:\"number\"}\n",
     "batch_size = 36 #@param {type:\"integer\"}\n",
+    "init_population_size = 100 #@param {type:\"integer\"}\n",
     "#@markdown ---"
    ]
   },
@@ -63,7 +82,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defines the scoring function: rastrigin"
+    "## Defines the scoring function: rastrigin\n",
+    "\n",
+    "As we are in the Differentiable QD setting, the scoring function does not only retrieve the fitness and descriptors, but also the gradients."
    ]
   },
   {
@@ -141,7 +162,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Define the population, the emitter and the MAP Elites instance"
+    "## Define the initial population, the emitter and the MAP Elites instance\n",
+    "\n",
+    "The emitter is defined using the OMGMEGA emitter class. This emitter is given to a MAP-Elites instance to create an instance of the OMG-MEGA algorithm. "
    ]
   },
   {
@@ -154,7 +177,7 @@
     "\n",
     "# defines the population\n",
     "random_key, subkey = jax.random.split(random_key)\n",
-    "initial_population = jax.random.uniform(subkey, shape=(100, num_dimensions))\n",
+    "initial_population = jax.random.uniform(subkey, shape=(init_population_size, num_dimensions))\n",
     "centroids = compute_euclidean_centroids(\n",
     "    num_descriptors = num_descriptors,\n",
     "    num_centroids = num_centroids,\n",
@@ -240,13 +263,6 @@
     "    env_steps=env_steps, metrics=metrics, repertoire=repertoire, min_bd=minval, max_bd=maxval\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/omgmega_example.ipynb
+++ b/notebooks/omgmega_example.ipynb
@@ -1,0 +1,276 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax \n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "try:\n",
+    "    import qdax\n",
+    "except:\n",
+    "    !pip install --no-deps git+https://github.com/adaptive-intelligent-robotics/QDax@main |tail -n 1\n",
+    "    import qdax\n",
+    "\n",
+    "from qdax.core.map_elites import MAPElites\n",
+    "from qdax.core.emitters.omg_mega_emitter import OMGMEGAEmitter\n",
+    "from qdax.core.containers.repertoire import compute_euclidean_centroids, MapElitesRepertoire\n",
+    "from qdax.utils.plotting import plot_map_elites_results\n",
+    "\n",
+    "from typing import Dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set the hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title QD Training Definitions Fields\n",
+    "#@markdown ---\n",
+    "num_iterations = 20000 #@param {type:\"integer\"}\n",
+    "num_dimensions = 1000 #@param {type:\"integer\"}\n",
+    "num_centroids = 10000 #@param {type:\"integer\"}\n",
+    "num_descriptors = 2 #@param {type:\"integer\"}\n",
+    "sigma_g=10\n",
+    "minval = -5.12 #@param {type:\"number\"}\n",
+    "maxval = 5.12 #@param {type:\"number\"}\n",
+    "batch_size = 36 #@param {type:\"integer\"}\n",
+    "#@markdown ---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defines the scoring function: rastrigin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rastrigin_scoring(x: jnp.ndarray):\n",
+    "    return -(10 * x.shape[-1] + jnp.sum((x+minval*0.4)**2 - 10 * jnp.cos(2 * jnp.pi * (x+minval*0.4))))\n",
+    "\n",
+    "def clip(x: jnp.ndarray):\n",
+    "    return x*(x<=maxval)*(x>=+minval) + maxval/x*((x>maxval)+(x<+minval))\n",
+    "\n",
+    "def _rastrigin_descriptor_1(x: jnp.ndarray):\n",
+    "    return jnp.mean(clip(x[:x.shape[0]//2]))\n",
+    "\n",
+    "def _rastrigin_descriptor_2(x: jnp.ndarray):\n",
+    "    return jnp.mean(clip(x[x.shape[0]//2:]))\n",
+    "\n",
+    "def rastrigin_descriptors(x: jnp.ndarray):\n",
+    "    return jnp.array([_rastrigin_descriptor_1(x), _rastrigin_descriptor_2(x)])\n",
+    "\n",
+    "rastrigin_grad_scores = jax.grad(rastrigin_scoring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scoring_function(x):\n",
+    "    fitnesses, descriptors = rastrigin_scoring(x), rastrigin_descriptors(x)\n",
+    "    gradients = jnp.array([rastrigin_grad_scores(x), jax.grad(_rastrigin_descriptor_1)(x), jax.grad(_rastrigin_descriptor_2)(x)]).T\n",
+    "    gradients = jnp.nan_to_num(gradients)\n",
+    "    return fitnesses, descriptors, {\"gradients\": gradients}\n",
+    "\n",
+    "def scoring_fn(x, random_key):\n",
+    "    fitnesses, descriptors, extra_scores = jax.vmap(scoring_function)(x)\n",
+    "    return fitnesses, descriptors, extra_scores, random_key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the metrics that will be used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "worst_objective = rastrigin_scoring(-jnp.ones(num_dimensions) * maxval)\n",
+    "best_objective = rastrigin_scoring(jnp.ones(num_dimensions) * maxval * 0.4)\n",
+    "\n",
+    "\n",
+    "def metrics_fn(repertoire: MapElitesRepertoire) -> Dict[str, jnp.ndarray]:\n",
+    "\n",
+    "    # get metrics\n",
+    "    grid_empty = repertoire.fitnesses == -jnp.inf\n",
+    "    adjusted_fitness = (\n",
+    "        (repertoire.fitnesses - worst_objective) / (best_objective - worst_objective)\n",
+    "    )\n",
+    "    qd_score = jnp.sum(adjusted_fitness, where=~grid_empty) / num_centroids\n",
+    "    coverage = 100 * jnp.mean(1.0 - grid_empty)\n",
+    "    max_fitness = jnp.max(adjusted_fitness)\n",
+    "    return {\"qd_score\": qd_score, \"max_fitness\": max_fitness, \"coverage\": coverage}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the population, the emitter and the MAP Elites instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_key = jax.random.PRNGKey(0)\n",
+    "\n",
+    "# defines the population\n",
+    "random_key, subkey = jax.random.split(random_key)\n",
+    "initial_population = jax.random.uniform(subkey, shape=(100, num_dimensions))\n",
+    "centroids = compute_euclidean_centroids(\n",
+    "    num_descriptors = num_descriptors,\n",
+    "    num_centroids = num_centroids,\n",
+    "    minval = minval,\n",
+    "    maxval = maxval\n",
+    ") \n",
+    "\n",
+    "# defines the emitter\n",
+    "emitter = OMGMEGAEmitter(\n",
+    "    batch_size=batch_size,\n",
+    "    sigma_g=sigma_g,\n",
+    "    num_descriptors=num_descriptors,\n",
+    "    centroids=centroids\n",
+    ")\n",
+    "\n",
+    "# create the MAP Elites instance\n",
+    "map_elites = MAPElites(\n",
+    "    scoring_function=scoring_fn,\n",
+    "    emitter=emitter,\n",
+    "    metrics_function=metrics_fn\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialise MAP Elites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repertoire, emitter_state, random_key = map_elites.init(initial_population, centroids, random_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run MAP Elites iterations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "(repertoire, emitter_state, random_key,), metrics = jax.lax.scan(\n",
+    "    map_elites.scan_update,\n",
+    "    (repertoire, emitter_state, random_key),\n",
+    "    (),\n",
+    "    length=num_iterations,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title Visualization\n",
+    "\n",
+    "# create the x-axis array\n",
+    "env_steps = jnp.arange(num_iterations) * batch_size\n",
+    "\n",
+    "# create the plots and the grid\n",
+    "fig, axes = plot_map_elites_results(\n",
+    "    env_steps=env_steps, metrics=metrics, repertoire=repertoire, min_bd=minval, max_bd=maxval\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "a5f11f0c88ac347de253fd12f7bdd97be5b86afe71b01b860214a94915ded25a"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/qdax/core/emitters/omg_mega_emitter.py
+++ b/qdax/core/emitters/omg_mega_emitter.py
@@ -1,0 +1,242 @@
+from functools import partial
+from typing import Callable, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from qdax.core.containers.repertoire import MapElitesRepertoire
+from qdax.core.emitters.emitter import Emitter, EmitterState
+from qdax.types import Centroid, Descriptor, ExtraScores, Fitness, Genotype, RNGKey
+
+
+class OMGMEGAEmitterState(EmitterState):
+    """
+    Emitter state for the CMA-MEGA emitter.
+
+    Args:
+        gradients_repertoire: MapElites repertoire containing the gradients
+            of the indivuals.
+    """
+
+    gradients_repertoire: MapElitesRepertoire
+
+
+class OMGMEGAEmitter(Emitter):
+    """
+    Class for the emitter of OMG Mega from "Differentiable Quality Diversity" by
+    Fontaine et al.
+
+    NOTE: in order to implement this emitter while staying in the MAPElites
+    framework, we had to make two temporary design choices:
+    - in the emit_fn function, we use the same random key to sample from the
+    genotypes and gradients repertoire, in order to get the gradients that
+    correspond to the right genotypes. Although acceptable, this is definitely
+    not the best coding practice and we would prefer to get rid of this in a
+    future version. A solution that we are discussing with the development team
+    is to decompose the sampling function of the repertoire into two phases: one
+    sampling the indices to be sampled, the other one retrieving the corresponding
+    elements. This would enable to reuse the indices instead of doing this double
+    sampling.
+    - in the state_update_fn, we have to insert the gradients in the gradients
+    repertoire in the same way the individuals were inserted. Once again, this is
+    slightly unoptimal because the same addition mecanism has to be computed two
+    times. One solution that we are discussing and that is very similar to the first
+    solution discussed above, would be to decompose the addition mecanism in two
+    phases: one outputing the indices at which individuals will be added, and then
+    the actual insertion step. This would enable to re-use the same indices to add
+    the gradients instead of having to recompute them.
+
+    The two design choices seem acceptable and enable to have OMG MEGA compatible
+    with the current implementation of the MAPElites and MAPElitesRepertoire classes.
+
+    Our suggested solutions seem quite simple and are likely to be useful for other
+    variants implementation. They will be further discussed with the development team
+    and potentially added in a future version of the package.
+    """
+
+    def __init__(
+        self,
+        batch_size: int,
+        sigma_g: float,
+        num_descriptors: int,
+        centroids: Centroid,
+        projection_fn: Optional[Callable[[Genotype], Genotype]] = None,
+    ):
+        """Creates an instance of the OMGMEGAEmitter class.
+
+        Args:
+            batch_size: number of solutions sampled at each iteration
+            sigma_g: standard deviation for the coefficients
+            num_descriptors: number of descriptors
+            centroids: centroids used to create the repertoire of solutions.
+                This will be used to create the repertoire of gradients.
+            projection_fn: function to project the solutions back to their admissible
+                space.
+        """
+        self._mu = jnp.zeros(num_descriptors + 1)
+        self._sigma = jnp.eye(num_descriptors + 1) * sigma_g
+        self._batch_size = batch_size
+        self._centroids = centroids
+        self._num_descriptors = num_descriptors
+        if projection_fn:
+            self._projection_fn = projection_fn
+        else:
+            self._projection_fn = lambda x: x
+
+    def init(
+        self, init_genotypes: Genotype, random_key: RNGKey
+    ) -> Tuple[OMGMEGAEmitterState, RNGKey]:
+        """Initialises the state of the emitter. Creates an empty repertoire
+        that will later contain the gradients of the individuals.
+
+        Args:
+            init_genotypes: The genotypes of the initial population.
+            random_key: a random key to handle stochastic operations.
+
+        Returns:
+            The initial emitter state.
+        """
+
+        # Initialize grid with default values
+        num_centroids = self._centroids.shape[0]
+        default_fitnesses = -jnp.inf * jnp.ones(shape=num_centroids)
+        default_gradients = jax.tree_map(
+            lambda x: jnp.zeros(
+                shape=(num_centroids,) + x.shape[1:] + (self._num_descriptors + 1,)
+            ),
+            init_genotypes,
+        )
+        default_descriptors = jnp.zeros(
+            shape=(num_centroids, self._centroids.shape[-1])
+        )
+
+        # instantiate de gradients repertoire
+        gradients_repertoire = MapElitesRepertoire(
+            genotypes=default_gradients,
+            fitnesses=default_fitnesses,
+            descriptors=default_descriptors,
+            centroids=self._centroids,
+        )
+
+        return (
+            OMGMEGAEmitterState(gradients_repertoire=gradients_repertoire),
+            random_key,
+        )
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
+    def emit(
+        self,
+        repertoire: MapElitesRepertoire,
+        emitter_state: OMGMEGAEmitterState,
+        random_key: RNGKey,
+    ) -> Tuple[Genotype, RNGKey]:
+        """
+        OMG emitter function that samples elements in the repertoire and does a gradient
+        update with random coefficients to create new candidates.
+
+        Args:
+            repertoire: current repertoire
+            emitter_state: current emitter state, contains the gradients
+            random_key: random key
+
+        Returns:
+            new_genotypes: new candidates to be added to the grid
+            random_key: updated random key
+        """
+        # sample genotypes
+        (
+            genotypes,
+            _,
+        ) = repertoire.sample(random_key, num_samples=self._batch_size)
+
+        # sample gradients - use the same random key for sampling
+        # See class docstrings for discussion about this choice
+        (gradients, random_key,) = emitter_state.gradients_repertoire.sample(
+            random_key, num_samples=self._batch_size
+        )
+
+        fitness_gradients = jax.tree_map(
+            lambda x: jnp.expand_dims(x[:, :, 0], axis=-1), gradients
+        )
+        descriptors_gradients = jax.tree_map(lambda x: x[:, :, 1:], gradients)
+
+        # Normalize the gradients
+        norm_fitness_gradients = jnp.linalg.norm(
+            fitness_gradients, axis=1, keepdims=True
+        )
+
+        fitness_gradients = fitness_gradients / norm_fitness_gradients
+
+        norm_descriptors_gradients = jnp.linalg.norm(
+            descriptors_gradients, axis=1, keepdims=True
+        )
+        descriptors_gradients = descriptors_gradients / norm_descriptors_gradients
+
+        # Draw random coefficients
+        random_key, subkey = jax.random.split(random_key)
+        coeffs = jax.random.multivariate_normal(
+            subkey,
+            shape=(self._batch_size,),
+            mean=self._mu,
+            cov=self._sigma,
+        )
+        coeffs = coeffs.at[:, 0].set(jnp.abs(coeffs[:, 0]))
+        grads = jax.tree_map(
+            lambda x, y: jnp.concatenate((x, y), axis=-1),
+            fitness_gradients,
+            descriptors_gradients,
+        )
+        update_grad = jnp.sum(jax.vmap(lambda x, y: x * y)(coeffs, grads), axis=-1)
+
+        # update the genotypes
+        new_genotypes = jax.tree_map(lambda x, y: x + y, genotypes, update_grad)
+
+        # Project if needed
+        new_genotypes = self._projection_fn(new_genotypes)
+
+        return new_genotypes, random_key
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
+    def state_update(
+        self,
+        emitter_state: OMGMEGAEmitterState,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
+    ) -> OMGMEGAEmitterState:
+        """Update the gradients repertoire to have the right gradients.
+
+        NOTE: see discussion in the class docstrings to see how this could
+        be improved.
+
+        Args:
+            emitter_state: current emitter state
+            genotypes: the genotypes of the batch of emitted offspring.
+            fitnesses: the fitnesses of the batch of emitted offspring.
+            descriptors: the descriptors of the emitted offspring.
+            extra_scores: a dictionary with other values outputted by the
+                scoring function.
+
+        Returns:
+            The modified emitter state.
+        """
+
+        # get gradients out of the extra scores
+        assert "gradients" in extra_scores.keys(), "Missing gradients or wrong key"
+        gradients = extra_scores["gradients"]
+
+        # update the gradients repertoire
+        gradients_repertoire = emitter_state.gradients_repertoire.add(
+            gradients, descriptors, fitnesses
+        )
+
+        return emitter_state.replace(  # type: ignore
+            gradients_repertoire=gradients_repertoire
+        )

--- a/tests/core_test/omgmega_test.py
+++ b/tests/core_test/omgmega_test.py
@@ -1,0 +1,126 @@
+from typing import Dict, Tuple
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from qdax.core.containers.repertoire import (
+    MapElitesRepertoire,
+    compute_euclidean_centroids,
+)
+from qdax.core.emitters.omg_mega_emitter import OMGMEGAEmitter
+from qdax.core.map_elites import MAPElites
+from qdax.types import Descriptor, ExtraScores, Fitness, Genotype, RNGKey
+
+
+def test_omg_mega() -> None:
+
+    num_iterations = 200
+    num_dimensions = 1000
+    num_centroids = 10000
+    num_descriptors = 2
+    sigma_g = 10
+    minval = -5.12
+    maxval = 5.12
+    batch_size = 36
+
+    def rastrigin_scoring(x: jnp.ndarray) -> Fitness:
+        return -(
+            10 * x.shape[-1]
+            + jnp.sum(
+                (x + minval * 0.4) ** 2 - 10 * jnp.cos(2 * jnp.pi * (x + minval * 0.4))
+            )
+        )
+
+    def clip(x: jnp.ndarray) -> jnp.ndarray:
+        return x * (x <= maxval) * (x >= minval) + maxval / x * (
+            (x > maxval) + (x < minval)
+        )
+
+    def _rastrigin_descriptor_1(x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.mean(clip(x[: x.shape[0] // 2]))
+
+    def _rastrigin_descriptor_2(x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.mean(clip(x[x.shape[0] // 2 :]))
+
+    def rastrigin_descriptors(x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.array([_rastrigin_descriptor_1(x), _rastrigin_descriptor_2(x)])
+
+    rastrigin_grad_scores = jax.grad(rastrigin_scoring)
+
+    def scoring_function(x: jnp.ndarray) -> Tuple[Fitness, Descriptor, ExtraScores]:
+        fitnesses, descriptors = rastrigin_scoring(x), rastrigin_descriptors(x)
+        gradients = jnp.array(
+            [
+                rastrigin_grad_scores(x),
+                jax.grad(_rastrigin_descriptor_1)(x),
+                jax.grad(_rastrigin_descriptor_2)(x),
+            ]
+        ).T
+        gradients = jnp.nan_to_num(gradients)
+        return fitnesses, descriptors, {"gradients": gradients}
+
+    def scoring_fn(
+        x: Genotype, random_key: RNGKey
+    ) -> Tuple[Fitness, Descriptor, ExtraScores, RNGKey]:
+        fitnesses, descriptors, extra_scores = jax.vmap(scoring_function)(x)
+        return fitnesses, descriptors, extra_scores, random_key
+
+    worst_objective = rastrigin_scoring(-jnp.ones(num_dimensions) * maxval)
+    best_objective = rastrigin_scoring(jnp.ones(num_dimensions) * maxval * 0.4)
+
+    def metrics_fn(repertoire: MapElitesRepertoire) -> Dict[str, jnp.ndarray]:
+
+        # get metrics
+        grid_empty = repertoire.fitnesses == -jnp.inf
+        adjusted_fitness = (repertoire.fitnesses - worst_objective) / (
+            best_objective - worst_objective
+        )
+        qd_score = jnp.sum(adjusted_fitness, where=~grid_empty) / num_centroids
+        coverage = 100 * jnp.mean(1.0 - grid_empty)
+        max_fitness = jnp.max(adjusted_fitness)
+        return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
+
+    random_key = jax.random.PRNGKey(0)
+
+    # defines the population
+    random_key, subkey = jax.random.split(random_key)
+    initial_population = jax.random.uniform(subkey, shape=(100, num_dimensions))
+    centroids = compute_euclidean_centroids(
+        num_descriptors=num_descriptors,
+        num_centroids=num_centroids,
+        minval=minval,
+        maxval=maxval,
+    )
+
+    # defines the emitter
+    emitter = OMGMEGAEmitter(
+        batch_size=batch_size,
+        sigma_g=sigma_g,
+        num_descriptors=num_descriptors,
+        centroids=centroids,
+    )
+
+    # create the MAP Elites instance
+    map_elites = MAPElites(
+        scoring_function=scoring_fn, emitter=emitter, metrics_function=metrics_fn
+    )
+
+    repertoire, emitter_state, random_key = map_elites.init(
+        initial_population, centroids, random_key
+    )
+
+    (repertoire, emitter_state, random_key,), metrics = jax.lax.scan(
+        map_elites.scan_update,
+        (repertoire, emitter_state, random_key),
+        (),
+        length=num_iterations,
+    )
+
+    pytest.assume(metrics["coverage"][-1] > 5)
+    pytest.assume(metrics["max_fitness"][-1] > 0.5)
+    pytest.assume(metrics["qd_score"][-1] > 0.05)
+
+
+if __name__ == "__main__":
+    test_omg_mega()


### PR DESCRIPTION
Related to issue [#19](https://github.com/adaptive-intelligent-robotics/QDax/issues/19)

This PR adds OMG MEGA (Objective and Measure Gradient MAP-Elites via Gradient Arborescence), a baseline from the paper [Differentiable Quality Diversity](https://arxiv.org/pdf/2106.03894.pdf).

In this algorithm, one suppose access to the derivatives of the scoring function (fitness and behavior descriptor).

**Future improvement:**
Double addition in the archive: in this implementation, in order to fit into the actual design of MAP-Elites, we have to compute the addition in the grid two times. As a matter of fact, gradients are stored in a grid repertoire, just like the genotypes, and when the scoring is made, the gradients are updated in the gradients repertoire just like it has been made in the genotypes repertoire. A better solution would be to have access to the indices from the addition mecanism to avoid having to re-compute them. This will be discussed in the future with the development team to this if we can improve this.