### PR TITLE
Update requirements: upgrade numpy and jax

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -43,7 +43,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-11.0/targets/x86_64-linux/l
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN pip --no-cache-dir install jaxlib==0.3.10+cuda11.cudnn82 \
-    -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+    -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
     && rm -rf /tmp/*
 
 WORKDIR $APP_FOLDER

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -42,7 +42,7 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-11.0/targets/x86_64-linux/l
 
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN pip --no-cache-dir install jaxlib==0.3.2+cuda11.cudnn82 \
+RUN pip --no-cache-dir install jaxlib==0.3.10+cuda11.cudnn82 \
     -f https://storage.googleapis.com/jax-releases/jax_releases.html \
     && rm -rf /tmp/*
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,6 @@ dependencies:
 - conda>=4.9.2
 - pip:
     - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jaxlib>=0.3.10
+    - jaxlib==0.3.10
     - -r requirements.txt
     - -r requirements-dev.txt

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,6 @@ dependencies:
 - conda>=4.9.2
 - pip:
     - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jaxlib==0.3.2
+    - jaxlib>=0.3.10
     - -r requirements.txt
     - -r requirements-dev.txt

--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -9,9 +9,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax.flatten_util import ravel_pytree
-from sklearn.cluster import KMeans
-
 from qdax.types import Centroid, Descriptor, Fitness, Genotype, RNGKey
+from sklearn.cluster import KMeans
 
 
 def compute_cvt_centroids(
@@ -273,7 +272,7 @@ class MapElitesRepertoire(flax.struct.PyTreeNode):
         )
 
         # create new grid
-        new_grid_genotypes = jax.tree_multimap(
+        new_grid_genotypes = jax.tree_map(
             lambda grid_genotypes, new_genotypes: grid_genotypes.at[
                 batch_of_indices.squeeze()
             ].set(new_genotypes),

--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -9,8 +9,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax.flatten_util import ravel_pytree
-from qdax.types import Centroid, Descriptor, Fitness, Genotype, RNGKey
 from sklearn.cluster import KMeans
+
+from qdax.types import Centroid, Descriptor, Fitness, Genotype, RNGKey
 
 
 def compute_cvt_centroids(

--- a/qdax/core/emitters/pga_me_emitter.py
+++ b/qdax/core/emitters/pga_me_emitter.py
@@ -9,14 +9,14 @@ import jax
 import optax
 from jax import numpy as jnp
 from jax.tree_util import tree_map
+
 from qdax.core.containers.repertoire import MapElitesRepertoire
 from qdax.core.emitters.emitter import Emitter, EmitterState
 from qdax.core.neuroevolution.buffers.buffer import QDTransition, ReplayBuffer
 from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_fn
 from qdax.core.neuroevolution.networks.networks import QModule
 from qdax.environments.base_wrappers import QDEnv
-from qdax.types import (Descriptor, ExtraScores, Fitness, Genotype, Params,
-                        RNGKey)
+from qdax.types import Descriptor, ExtraScores, Fitness, Genotype, Params, RNGKey
 
 
 @dataclass

--- a/qdax/core/emitters/pga_me_emitter.py
+++ b/qdax/core/emitters/pga_me_emitter.py
@@ -9,14 +9,14 @@ import jax
 import optax
 from jax import numpy as jnp
 from jax.tree_util import tree_map
-
 from qdax.core.containers.repertoire import MapElitesRepertoire
 from qdax.core.emitters.emitter import Emitter, EmitterState
 from qdax.core.neuroevolution.buffers.buffer import QDTransition, ReplayBuffer
 from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_fn
 from qdax.core.neuroevolution.networks.networks import QModule
 from qdax.environments.base_wrappers import QDEnv
-from qdax.types import Descriptor, ExtraScores, Fitness, Genotype, Params, RNGKey
+from qdax.types import (Descriptor, ExtraScores, Fitness, Genotype, Params,
+                        RNGKey)
 
 
 @dataclass
@@ -214,7 +214,7 @@ class PGEmitter(Emitter):
         )
 
         # gather offspring
-        genotypes = jax.tree_multimap(
+        genotypes = jax.tree_map(
             lambda x, y, z: jnp.concatenate([x, y, z], axis=0),
             x_mutation_ga,
             x_mutation_pg,
@@ -316,7 +316,7 @@ class PGEmitter(Emitter):
         )
         critic_params = optax.apply_updates(emitter_state.critic_params, critic_updates)
         # Soft update of target critic network
-        target_critic_params = jax.tree_multimap(
+        target_critic_params = jax.tree_map(
             lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
             + self._config.soft_tau_update * x2,
             emitter_state.target_critic_params,
@@ -340,7 +340,7 @@ class PGEmitter(Emitter):
             emitter_state.greedy_policy_params, policy_updates
         )
         # Soft update of target greedy policy
-        target_greedy_policy_params = jax.tree_multimap(
+        target_greedy_policy_params = jax.tree_map(
             lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
             + self._config.soft_tau_update * x2,
             emitter_state.target_greedy_policy_params,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 absl-py==1.0.0
 brax==0.0.12
 dm-haiku==0.0.5
-flax>=0.4.1
-gym>=0.15.4
+flax==0.4.1
+gym==0.23.1
 ipython
-jax>=0.3.10
+jax==0.3.10
 jupyter
-numpy>=1.22.3
-protobuf>=3.19.4
-scikit-learn>=1.0.1
-scipy>=1.7.3
-seaborn>=0.11.2
+numpy==1.22.3
+protobuf==3.19.4
+scikit-learn==1.0.2
+scipy==1.8.0
+seaborn==0.11.2
 sklearn==0.0
 tensorflow-probability==0.15.0
 typing-extensions == 3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 absl-py==1.0.0
 brax==0.0.12
 dm-haiku==0.0.5
-flax==0.4.1
-gym==0.19.0
+flax>=0.4.1
+gym>=0.15.4
 ipython
-jax==0.3.2
+jax>=0.3.10
 jupyter
-numpy==1.19.5
-protobuf==3.19.4
-scikit-learn==1.0.1
-scipy==1.7.3
-seaborn==0.11.2
+numpy>=1.22.3
+protobuf>=3.19.4
+scikit-learn>=1.0.1
+scipy>=1.7.3
+seaborn>=0.11.2
 sklearn==0.0
 tensorflow-probability==0.15.0
 typing-extensions == 3.10


### PR DESCRIPTION
This PR updates several requirements. It was initially created to address the GitHub dependabot security issue to do with the numpy version. 

It also increases the jax version to 0.3.10

**Notes:**
- the performances where quickly checked with a few seeds on PGAME but in the future it is important that we set up a way to check up the performance of most of the algorithms on several environments to make sure the performance is not impacted by version changes (and also by usual PRs)
- this PR has the same commits as #26, they were basically cherry-picked to have a branch out and in develop instead of master