### PR TITLE
Adding codecov to QDax for test coverage reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,13 @@ jobs:
 
       - name: Run pytests
         run: |
-          pytest -vv tests
+          coverage run -m pytest -vv tests
+          coverage xml
+
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+
+          chmod +x codecov
+          ./codecov
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,8 @@ jobs:
           coverage run -m pytest -vv tests
           coverage xml
 
+      - name: Upload coverage reports to Codecov
+        run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
 
           chmod +x codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,12 +122,6 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v2
 
-      # - name: Upload coverage reports to Codecov
-      #   run: |
-      #     curl -Os https://uploader.codecov.io/latest/linux/codecov
-
-      #     chmod +x codecov
-      #     ./codecov
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,12 +119,15 @@ jobs:
           coverage run -m pytest -vv tests
           coverage xml
 
-      - name: Upload coverage reports to Codecov
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v2
 
-          chmod +x codecov
-          ./codecov
+      # - name: Upload coverage reports to Codecov
+      #   run: |
+      #     curl -Os https://uploader.codecov.io/latest/linux/codecov
+
+      #     chmod +x codecov
+      #     ./codecov
 
   docs:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Documentation Status](https://readthedocs.org/projects/qdax/badge/?version=latest)](https://qdax.readthedocs.io/en/latest/?badge=latest)
 ![pytest](https://github.com/adaptive-intelligent-robotics/QDax/actions/workflows/ci.yaml/badge.svg?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/adaptive-intelligent-robotics/QDax/blob/main/LICENSE)
-
+[![codecov](https://codecov.io/gh/adaptive-intelligent-robotics/QDax/branch/feat/add-codecov/graph/badge.svg)](https://codecov.io/gh/adaptive-intelligent-robotics/QDax)
 
 
 # QDax: Accelerated Quality-Diversity

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+coverage
 pre-commit==2.12.1
 pytest==6.2.5
 pytest-assume==2.4.3


### PR DESCRIPTION
This PR adds codecov to QDax.

This enables to have tests reports and track the code covered by our tests.

**Notes:**
- change the link before merging in develop (and same for master in the future)
- would be nice to change the badge link for every branch (automatically)
- the upload works but the codecov interface still shows issues