### PR TITLE
fix: remove descriptors squeeze() to fix 1D-BD tasks

### DIFF
--- a/qdax/core/containers/mome_repertoire.py
+++ b/qdax/core/containers/mome_repertoire.py
@@ -288,10 +288,10 @@ class MOMERepertoire(MapElitesRepertoire):
                 cell_descriptor,
                 cell_mask,
             ) = self._update_masked_pareto_front(
-                pareto_front_fitnesses=cell_fitness.squeeze(),
-                pareto_front_genotypes=cell_genotype.squeeze(),
-                pareto_front_descriptors=cell_descriptor.squeeze(),
-                mask=cell_mask.squeeze(),
+                pareto_front_fitnesses=cell_fitness.squeeze(axis=0),
+                pareto_front_genotypes=cell_genotype.squeeze(axis=0),
+                pareto_front_descriptors=cell_descriptor.squeeze(axis=0),
+                mask=cell_mask.squeeze(axis=0),
                 new_batch_of_fitnesses=jnp.expand_dims(fitness, axis=0),
                 new_batch_of_genotypes=jnp.expand_dims(genotype, axis=0),
                 new_batch_of_descriptors=jnp.expand_dims(descriptors, axis=0),
@@ -307,6 +307,7 @@ class MOMERepertoire(MapElitesRepertoire):
             )
             new_fitnesses = carry.fitnesses.at[index].set(cell_fitness)
             new_descriptors = carry.descriptors.at[index].set(cell_descriptor)
+
             carry = carry.replace(  # type: ignore
                 genotypes=new_genotypes,
                 descriptors=new_descriptors,

--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -292,13 +292,13 @@ class MapElitesRepertoire(flax.struct.PyTreeNode):
             batch_of_fitnesses.squeeze()
         )
         new_descriptors = self.descriptors.at[batch_of_indices.squeeze()].set(
-            batch_of_descriptors.squeeze()
+            batch_of_descriptors
         )
 
         return MapElitesRepertoire(
             genotypes=new_repertoire_genotypes,
             fitnesses=new_fitnesses.squeeze(),
-            descriptors=new_descriptors.squeeze(),
+            descriptors=new_descriptors,
             centroids=self.centroids,
         )
 

--- a/qdax/core/sac.py
+++ b/qdax/core/sac.py
@@ -389,7 +389,7 @@ class SAC:
         critic_params = optax.apply_updates(
             training_state.critic_params, critic_updates
         )
-        target_critic_params = jax.tree_multimap(
+        target_critic_params = jax.tree_map(
             lambda x1, x2: (1.0 - self._config.tau) * x1 + self._config.tau * x2,
             training_state.target_critic_params,
             critic_params,

--- a/qdax/core/td3.py
+++ b/qdax/core/td3.py
@@ -303,7 +303,7 @@ class TD3:
             training_state.critic_params, critic_updates
         )
         # Soft update of target critic network
-        target_critic_params = jax.tree_multimap(
+        target_critic_params = jax.tree_map(
             lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
             + self._config.soft_tau_update * x2,
             training_state.target_critic_params,
@@ -325,7 +325,7 @@ class TD3:
                 training_state.policy_params, policy_updates
             )
             # Soft update of target policy
-            target_policy_params = jax.tree_multimap(
+            target_policy_params = jax.tree_map(
                 lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
                 + self._config.soft_tau_update * x2,
                 training_state.target_policy_params,

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -18,9 +18,10 @@ from qdax.core.neuroevolution.networks.networks import MLP
 from qdax.types import EnvState, Params, RNGKey
 
 
-def test_map_elites() -> None:
+@pytest.mark.parametrize("environment_name", ["walker2d_uni", "hopper_uni"])
+def test_map_elites(environment_name: str) -> None:
     batch_size = 10
-    env_name = "walker2d_uni"
+    env_name = environment_name
     episode_length = 100
     num_iterations = 5
     seed = 42
@@ -152,4 +153,4 @@ def test_map_elites() -> None:
 
 
 if __name__ == "__main__":
-    test_map_elites()
+    test_map_elites(environment_name="walker2d_uni")

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -18,11 +18,14 @@ from qdax.types import Descriptor, ExtraScores, Fitness, RNGKey
 from qdax.utils.metrics import compute_moqd_metrics
 
 
-def test_mome() -> None:
+@pytest.mark.parametrize("num_descriptors", [1, 2])
+def test_mome(num_descriptors: int) -> None:
 
     pareto_front_max_length = 50
     num_variables = 100
     num_iterations = 100
+
+    num_descriptors = num_descriptors
 
     num_centroids = 64
     minval = -2
@@ -41,7 +44,7 @@ def test_mome() -> None:
         """
         Rastrigin Scorer with first two dimensions as descriptors
         """
-        descriptors = genotypes[:, :2]
+        descriptors = genotypes[:, :num_descriptors]
         f1 = -(
             10 * genotypes.shape[1]
             + jnp.sum(
@@ -79,7 +82,7 @@ def test_mome() -> None:
     random_key = jax.random.PRNGKey(42)
     random_key, subkey = jax.random.split(random_key)
     init_genotypes = jax.random.uniform(
-        random_key,
+        subkey,
         (batch_size, num_variables),
         minval=minval,
         maxval=maxval,
@@ -109,7 +112,7 @@ def test_mome() -> None:
     )
 
     centroids = compute_cvt_centroids(
-        num_descriptors=2,
+        num_descriptors=num_descriptors,
         num_init_cvt_samples=20000,
         num_centroids=num_centroids,
         minval=minval,
@@ -138,4 +141,4 @@ def test_mome() -> None:
 
 
 if __name__ == "__main__":
-    test_mome()
+    test_mome(num_descriptors=1)


### PR DESCRIPTION
This PR aims to fix the container addition for 1D-BD tasks. With the current container implementation, 1D-BD tasks such as the Hopper-uni task for example (`hopper_uni`) returns the following error:

<img width="724" alt="Screenshot 2022-06-29 at 10 31 27" src="https://user-images.githubusercontent.com/61653012/176410800-867ff55c-a04e-4d7c-a1e2-50f4ea5ed488.png">

This is due to the `squeeze` of the descriptors done in the `add()` method of the repertoire. These `squeeze` are necessary for the fitnesses and indices as these arrays are explicitly `expand_dims` at the beginning of the `add()` method. However it is not needed for the descriptors that are not modified in the `add()` method.
Thus as a fix I propose to remove the `squeeze` for the descriptors. 

This change should not impact the results, but just in case I attached the experimental comparison on GPU with the original container implementation and the new proposed container implementation on the `ant_omni` and `walker2d_uni` tasks. I ran 5 replications, the difference between runs is due to the non-deterministic nature of computation on GPU. I also added the results for the `hopper_uni` after the fix.

<img width="887" alt="Screenshot 2022-06-29 at 11 08 35" src="https://user-images.githubusercontent.com/61653012/176411389-3eb5c1c4-c1fc-4ab2-be2e-df047aa92083.png">

