### PR TITLE
Using RNGKey for sampling CVT centroids and for KMeans

### DIFF
--- a/notebooks/cmamega_example.ipynb
+++ b/notebooks/cmamega_example.ipynb
@@ -192,12 +192,13 @@
     "random_key = jax.random.PRNGKey(0)\n",
     "initial_population = jax.random.uniform(random_key, shape=(batch_size, num_dimensions))\n",
     "\n",
-    "centroids = compute_cvt_centroids(\n",
+    "centroids, random_key = compute_cvt_centroids(\n",
     "    num_descriptors=2, \n",
     "    num_init_cvt_samples=10000, \n",
     "    num_centroids=num_centroids, \n",
     "    minval=minval, \n",
-    "    maxval=maxval\n",
+    "    maxval=maxval,\n",
+    "    random_key=random_key,\n",
     ")\n",
     "\n",
     "emitter = CMAMEGAEmitter(\n",
@@ -277,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/diayn_example.ipynb
+++ b/notebooks/diayn_example.ipynb
@@ -530,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/mapelites_example.ipynb
+++ b/notebooks/mapelites_example.ipynb
@@ -264,12 +264,13 @@
     ")\n",
     "\n",
     "# Compute the centroids\n",
-    "centroids = compute_cvt_centroids(\n",
+    "centroids, random_key = compute_cvt_centroids(\n",
     "    num_descriptors=env.behavior_descriptor_length,\n",
     "    num_init_cvt_samples=num_init_cvt_samples,\n",
     "    num_centroids=num_centroids,\n",
     "    minval=min_bd,\n",
     "    maxval=max_bd,\n",
+    "    random_key=random_key,\n",
     ")\n",
     "\n",
     "# Compute initial repertoire and emitter state\n",
@@ -511,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/mome_example.ipynb
+++ b/notebooks/mome_example.ipynb
@@ -239,12 +239,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "centroids = compute_cvt_centroids(\n",
+    "centroids, random_key = compute_cvt_centroids(\n",
     "    num_descriptors=2, \n",
     "    num_init_cvt_samples=20000, \n",
     "    num_centroids=num_centroids, \n",
     "    minval=minval, \n",
-    "    maxval=maxval\n",
+    "    maxval=maxval,\n",
+    "    random_key=random_key,\n",
     ")"
    ]
   },
@@ -413,7 +414,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/omgmega_example.ipynb
+++ b/notebooks/omgmega_example.ipynb
@@ -284,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/pgame_example.ipynb
+++ b/notebooks/pgame_example.ipynb
@@ -299,12 +299,13 @@
     ")\n",
     "\n",
     "# Compute the centroids\n",
-    "centroids = compute_cvt_centroids(\n",
+    "centroids, random_key = compute_cvt_centroids(\n",
     "    num_descriptors=env.behavior_descriptor_length,\n",
     "    num_init_cvt_samples=num_init_cvt_samples,\n",
     "    num_centroids=num_centroids,\n",
     "    minval=min_bd,\n",
     "    maxval=max_bd,\n",
+    "    random_key=random_key,\n",
     ")\n",
     "\n",
     "# compute initial repertoire\n",
@@ -390,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/smerl_example.ipynb
+++ b/notebooks/smerl_example.ipynb
@@ -545,7 +545,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -47,13 +47,13 @@ def compute_cvt_centroids(
     maxval = jnp.array(maxval)
     # assume here all values are in [0, 1] and rescale later
 
-    _key_training_instances, \
-        _key_k_means, \
-        random_key = jax.random.split(random_key,
-                                      num=3)
+    _key_training_instances, _key_k_means, random_key = jax.random.split(
+        random_key, num=3
+    )
 
-    x = jax.random.uniform(key=_key_training_instances,
-                           shape=(num_init_cvt_samples, num_descriptors))
+    x = jax.random.uniform(
+        key=_key_training_instances, shape=(num_init_cvt_samples, num_descriptors)
+    )
 
     k_means = KMeans(
         init="k-means++",

--- a/qdax/core/containers/repertoire.py
+++ b/qdax/core/containers/repertoire.py
@@ -45,21 +45,18 @@ def compute_cvt_centroids(
     """
     minval = jnp.array(minval)
     maxval = jnp.array(maxval)
+
     # assume here all values are in [0, 1] and rescale later
+    random_key, subkey = jax.random.split(random_key)
+    x = jax.random.uniform(key=subkey, shape=(num_init_cvt_samples, num_descriptors))
 
-    _key_training_instances, _key_k_means, random_key = jax.random.split(
-        random_key, num=3
-    )
-
-    x = jax.random.uniform(
-        key=_key_training_instances, shape=(num_init_cvt_samples, num_descriptors)
-    )
-
+    # compute k means
+    random_key, subkey = jax.random.split(random_key)
     k_means = KMeans(
         init="k-means++",
         n_clusters=num_centroids,
         n_init=1,
-        random_state=RandomState(_key_k_means),
+        random_state=RandomState(subkey),
     )
     k_means.fit(x)
     centroids = k_means.cluster_centers_

--- a/tests/core_test/cmamega_test.py
+++ b/tests/core_test/cmamega_test.py
@@ -97,12 +97,13 @@ def test_cma_mega() -> None:
         random_key, shape=(batch_size, num_dimensions)
     )
 
-    centroids = compute_cvt_centroids(
+    centroids, random_key = compute_cvt_centroids(
         num_descriptors=2,
         num_init_cvt_samples=10000,
         num_centroids=num_centroids,
         minval=minval,
         maxval=maxval,
+        random_key=random_key,
     )
 
     emitter = CMAMEGAEmitter(

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -127,12 +127,13 @@ def test_map_elites() -> None:
     )
 
     # Compute the centroids
-    centroids = compute_cvt_centroids(
+    centroids, random_key = compute_cvt_centroids(
         num_descriptors=env.behavior_descriptor_length,
         num_init_cvt_samples=num_init_cvt_samples,
         num_centroids=num_centroids,
         minval=min_bd,
         maxval=max_bd,
+        random_key=random_key,
     )
 
     # Compute initial repertoire

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -108,12 +108,13 @@ def test_mome() -> None:
         batch_size=batch_size,
     )
 
-    centroids = compute_cvt_centroids(
+    centroids, random_key = compute_cvt_centroids(
         num_descriptors=2,
         num_init_cvt_samples=20000,
         num_centroids=num_centroids,
         minval=minval,
         maxval=maxval,
+        random_key=random_key,
     )
 
     mome = MOME(

--- a/tests/core_test/pgame_test.py
+++ b/tests/core_test/pgame_test.py
@@ -156,12 +156,13 @@ def test_pgame_elites() -> None:
     )
 
     # Compute the centroids
-    centroids = compute_cvt_centroids(
+    centroids, random_key = compute_cvt_centroids(
         num_descriptors=env.behavior_descriptor_length,
         num_init_cvt_samples=num_init_cvt_samples,
         num_centroids=num_centroids,
         minval=min_bd,
         maxval=max_bd,
+        random_key=random_key,
     )
 
     # Instantiate MAP Elites


### PR DESCRIPTION
The `compute_cvt_centroids(...)` function is the only function in the code that relies on `numpy.random` (and not `jax.random`) to generate random points and run a k-means.

This PR modifies `compute_cvt_centroids(...)` to use the `jax.random` module instead of `numpy.random`, in order to stay consistent in the usage of random number generators.