### PR TITLE
Adding plot_multidimensional_map_elites_grid function

### DIFF
--- a/qdax/utils/plotting.py
+++ b/qdax/utils/plotting.py
@@ -502,3 +502,264 @@ def vector_to_rgb(angle: float, absolute: float) -> Any:
     absolute = (absolute + 0.5) / 1.5
 
     return mpl.colors.hsv_to_rgb((angle / 2 / np.pi, 1, absolute))
+
+
+def _get_projection_in_1d(
+    integer_coordinates: jnp.ndarray, bases_tuple: Tuple[int, ...]
+) -> int:
+    """Converts an integer vector into a single integer,
+    given tuple of bases to consider for conversion.
+
+    This conversion is ensured to be unique, provided that
+    for all index i: x[i] < bases_tuple[i].
+    The vector and tuple of bases must have the same length.
+
+    For example if x=jnp.array([3, 1, 2]) and the bases are (5, 7, 3).
+    then the projection is 3*(7*3) + 1*(3) + 2 = 47.
+
+    Args:
+        integer_coordinates: the coordinates of the points (should be integers).
+        bases_tuple: the bases to use.
+
+    Returns:
+        The projection of the point in 1D (int).
+    """
+    assert jnp.size(integer_coordinates) == len(
+        bases_tuple
+    ), "x should have the same size as bases"
+    integer_coordinates = integer_coordinates.ravel().tolist()
+    coordinate = 0
+    for x_coord, base in zip(integer_coordinates, bases_tuple):
+        coordinate = coordinate * base + x_coord
+    return coordinate
+
+
+def _get_projection_in_2d(
+    integer_coordinates: jnp.ndarray, bases: Tuple[int, ...]
+) -> Tuple[int, int]:
+    """
+    Projects an integer vector into a pair of integers,
+    (given tuple of bases to consider for conversion).
+
+    For example if x=jnp.array([3, 1, 2, 5]) and the bases are (5, 2, 3, 7).
+    then the projection is obtained by:
+    - projecting in 1D the point jnp.array([3, 2]) with the bases (5, 3)
+    - projecting in 1D the point jnp.array([1, 5]) with the bases (2, 7)
+
+    Args:
+        integer_coordinates: the coordinates of the points (should be integers).
+        bases_tuple: the bases to use.
+
+    Returns:
+        The projection of the point in 2D (pair of integers).
+    """
+    integer_coordinates = integer_coordinates.ravel()
+    x0 = _get_projection_in_1d(integer_coordinates[::2], bases[::2])
+    x1 = _get_projection_in_1d(integer_coordinates[1::2], bases[1::2])
+    return x0, x1
+
+
+def plot_multidimensional_map_elites_grid(
+    repertoire: MapElitesRepertoire,
+    minval: jnp.ndarray,
+    maxval: jnp.ndarray,
+    grid_shape: Tuple[int, ...],
+    ax: Optional[plt.Axes] = None,
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+) -> Tuple[Optional[Figure], Axes]:
+    """Plot a visual 2D representation of a multidimensional MAP-Elites repertoire
+    (where the dimensionality of descriptors can be greater than 2).
+
+    Args:
+        repertoire: the MAP-Elites repertoire to plot.
+        minval: minimum values for the descriptors
+        maxval: maximum values for the descriptors
+        grid_shape: the resolution of the grid.
+        ax: a matplotlib axe for the figure to plot. Defaults to None.
+        vmin: minimum value for the fitness. Defaults to None.
+        vmax: maximum value for the fitness. Defaults to None.
+
+    Raises:
+        ValueError: the resolution should be an int or a tuple
+
+    Returns:
+        A figure and axes object, corresponding to the visualisation of the
+        repertoire.
+    """
+
+    descriptors = repertoire.descriptors
+    fitnesses = repertoire.fitnesses
+
+    is_grid_empty = fitnesses.ravel() == -jnp.inf
+    num_descriptors = descriptors.shape[1]
+
+    if isinstance(grid_shape, tuple):
+        assert (
+            len(grid_shape) == num_descriptors
+        ), "resolution should have the same length as num_descriptors"
+    else:
+        raise ValueError("resolution should be a tuple")
+
+    assert np.size(minval) == num_descriptors or np.size(minval) == 1, (
+        f"minval : {minval} should either be of size 1 "
+        f"or have the same size as the number of descriptors: {num_descriptors}"
+    )
+    assert np.size(maxval) == num_descriptors or np.size(maxval) == 1, (
+        f"maxval : {maxval} should either be of size 1 "
+        f"or have the same size as the number of descriptors: {num_descriptors}"
+    )
+
+    non_empty_descriptors = descriptors[~is_grid_empty]
+    non_empty_fitnesses = fitnesses[~is_grid_empty]
+
+    # convert the descriptors to integer coordinates, depending on the resolution.
+    resolutions_array = jnp.array(grid_shape)
+    descriptors_integers = jnp.asarray(
+        jnp.floor(
+            resolutions_array * (non_empty_descriptors - minval) / (maxval - minval)
+        ),
+        dtype=jnp.int32,
+    )
+
+    # total number of grid cells along each dimension of the grid
+    size_grid_x = np.prod(np.array(grid_shape[0::2]))
+    size_grid_y = np.prod(np.array(grid_shape[1::2]))
+
+    # initialise the grid
+    grid_2d = jnp.full(
+        (size_grid_x, size_grid_y),
+        fill_value=jnp.nan,
+    )
+
+    # put solutions in the grid according to their projected 2-dimensional coordinates
+    for _, (desc, fit) in enumerate(zip(descriptors_integers, non_empty_fitnesses)):
+        projection_2d = _get_projection_in_2d(desc, grid_shape)
+        if jnp.isnan(grid_2d[projection_2d]) or fit.item() > grid_2d[projection_2d]:
+            grid_2d = grid_2d.at[projection_2d].set(fit.item())
+
+    # set plot parameters
+    font_size = 12
+    params = {
+        "axes.labelsize": font_size,
+        "legend.fontsize": font_size,
+        "xtick.labelsize": font_size,
+        "ytick.labelsize": font_size,
+        "text.usetex": False,
+        "figure.figsize": [10, 10],
+    }
+
+    mpl.rcParams.update(params)
+
+    # create the plot object
+    fig = None
+    if ax is None:
+        fig, ax = plt.subplots(facecolor="white", edgecolor="white")
+    ax.set(adjustable="box", aspect="equal")
+
+    my_cmap = cm.viridis
+
+    if vmin is None:
+        vmin = float(jnp.min(non_empty_fitnesses))
+    if vmax is None:
+        vmax = float(jnp.max(non_empty_fitnesses))
+
+    ax.imshow(
+        grid_2d.T,
+        origin="lower",
+        aspect="equal",
+        vmin=vmin,
+        vmax=vmax,
+        cmap=my_cmap,
+    )
+
+    # aesthetic
+    ax.set_xlabel("Behavior Dimension 1")
+    ax.set_ylabel("Behavior Dimension 2")
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="5%", pad=0.05)
+    norm = Normalize(vmin=vmin, vmax=vmax)
+    cbar = plt.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=my_cmap), cax=cax)
+    cbar.ax.tick_params(labelsize=font_size)
+
+    ax.set_title("MAP-Elites Grid")
+    ax.set_aspect("equal")
+
+    def _get_ticks_positions(
+        total_size_grid_axis: int, step_ticks_on_axis: int
+    ) -> jnp.ndarray:
+        """
+        Get the positions of the ticks on the grid axis.
+
+        Args:
+            total_size_grid_axis: total size of the grid axis
+            step_ticks_on_axis: step of the ticks
+
+        Returns:
+            The positions of the ticks on the plot.
+        """
+        return np.arange(0, total_size_grid_axis + 1, step_ticks_on_axis) - 0.5
+
+    # Ticks position
+    major_ticks_x = _get_ticks_positions(
+        size_grid_x.item(), step_ticks_on_axis=np.prod(grid_shape[2::2]).item()
+    )
+    minor_ticks_x = _get_ticks_positions(
+        size_grid_x.item(), step_ticks_on_axis=np.prod(grid_shape[4::2]).item()
+    )
+    major_ticks_y = _get_ticks_positions(
+        size_grid_y.item(), step_ticks_on_axis=np.prod(grid_shape[3::2]).item()
+    )
+    minor_ticks_y = _get_ticks_positions(
+        size_grid_y.item(), step_ticks_on_axis=np.prod(grid_shape[5::2]).item()
+    )
+
+    ax.set_xticks(
+        major_ticks_x,
+    )
+    ax.set_xticks(
+        minor_ticks_x,
+        minor=True,
+    )
+    ax.set_yticks(
+        major_ticks_y,
+    )
+    ax.set_yticks(
+        minor_ticks_y,
+        minor=True,
+    )
+
+    # Ticks aesthetics
+    ax.tick_params(
+        which="minor",
+        color="gray",
+        labelcolor="gray",
+        size=5,
+    )
+    ax.tick_params(
+        which="major",
+        labelsize=font_size,
+        size=7,
+    )
+
+    ax.grid(which="minor", alpha=1.0, color="#000000", linewidth=0.5)
+    ax.grid(which="major", alpha=1.0, color="#000000", linewidth=2.5)
+
+    ax.set_xticklabels(
+        [
+            f"{x:.2}"
+            for x in jnp.around(
+                jnp.linspace(minval[0], maxval[0], num=len(major_ticks_x)), decimals=2
+            )
+        ]
+    )
+    ax.set_yticklabels(
+        [
+            f"{y:.2}"
+            for y in jnp.around(
+                jnp.linspace(minval[1], maxval[1], num=len(major_ticks_y)), decimals=2
+            )
+        ]
+    )
+
+    return fig, ax

--- a/qdax/utils/plotting.py
+++ b/qdax/utils/plotting.py
@@ -527,18 +527,21 @@ def _get_projection_in_1d(
     assert jnp.size(integer_coordinates) == len(
         bases_tuple
     ), "x should have the same size as bases"
+
     integer_coordinates = integer_coordinates.ravel().tolist()
+
+    # build the conversion
     coordinate = 0
     for x_coord, base in zip(integer_coordinates, bases_tuple):
         coordinate = coordinate * base + x_coord
+
     return coordinate
 
 
 def _get_projection_in_2d(
     integer_coordinates: jnp.ndarray, bases: Tuple[int, ...]
 ) -> Tuple[int, int]:
-    """
-    Projects an integer vector into a pair of integers,
+    """Projects an integer vector into a pair of integers,
     (given tuple of bases to consider for conversion).
 
     For example if x=jnp.array([3, 1, 2, 5]) and the bases are (5, 2, 3, 7).
@@ -597,7 +600,7 @@ def plot_multidimensional_map_elites_grid(
     if isinstance(grid_shape, tuple):
         assert (
             len(grid_shape) == num_descriptors
-        ), "resolution should have the same length as num_descriptors"
+        ), "grid_shape should have the same length as num_descriptors"
     else:
         raise ValueError("resolution should be a tuple")
 
@@ -624,7 +627,8 @@ def plot_multidimensional_map_elites_grid(
 
     # total number of grid cells along each dimension of the grid
     size_grid_x = np.prod(np.array(grid_shape[0::2]))
-    size_grid_y = np.prod(np.array(grid_shape[1::2]))
+    # convert to int for the 1d case - if not, value 1.0 is given
+    size_grid_y = np.prod(np.array(grid_shape[1::2]), dtype=int)
 
     # initialise the grid
     grid_2d = jnp.full(

--- a/tests/utils_test/plotting_test.py
+++ b/tests/utils_test/plotting_test.py
@@ -1,0 +1,67 @@
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from qdax.core.containers.repertoire import MapElitesRepertoire
+from qdax.utils.plotting import plot_multidimensional_map_elites_grid
+
+
+@pytest.mark.parametrize(
+    "num_descriptors, grid_shape",
+    [
+        (1, (4,)),
+        (
+            2,
+            (
+                4,
+                4,
+            ),
+        ),
+        (
+            3,
+            (
+                4,
+                4,
+                4,
+            ),
+        ),
+        (3, (4, 4, 2)),
+        (4, (4, 4, 4, 4)),
+    ],
+)
+def test_onion_grid(num_descriptors: int, grid_shape: Tuple[int, ...]) -> None:
+    num_descriptors = num_descriptors
+    grid_shape = grid_shape
+
+    minval = jnp.array([0] * num_descriptors)
+    maxval = jnp.array([1] * num_descriptors)
+
+    random_key = jax.random.PRNGKey(seed=0)
+    random_key, key_desc, key_fit = jax.random.split(random_key, num=3)
+
+    number_samples_test = 300
+    descriptors = jax.random.uniform(
+        key_desc, shape=(number_samples_test, num_descriptors)
+    )
+    fitnesses = jax.random.uniform(key_fit, shape=(number_samples_test,))
+    # Uncomment to test with "empty" descriptors
+    # fitnesses = fitnesses.at[10:].set(-jnp.inf)
+
+    repertoire = MapElitesRepertoire(None, fitnesses, descriptors, None)
+
+    fig, ax = plot_multidimensional_map_elites_grid(
+        repertoire=repertoire,
+        minval=minval,
+        maxval=maxval,
+        grid_shape=grid_shape,
+        vmin=0,
+        vmax=1,
+    )
+
+    pytest.assume(fig is not None)
+
+
+if __name__ == "__main__":
+    test_onion_grid(num_descriptors=4, grid_shape=(4, 4, 4, 4))


### PR DESCRIPTION
Adding a function `plot_multidimensional_map_elites_grid` for showing grids when the dimensionality of the descriptors is greater than 2.

Here are some examples of plots that are generated:
- for a `grid_shape` of `(4, 4, 2)` (with `dimensionality_descriptors=3`)
<img width="603" alt="Screenshot 2022-07-04 at 19 07 30" src="https://user-images.githubusercontent.com/32456875/177203357-f9476a8a-8885-4e2d-8678-713af58d3af1.png">

- for a `grid_shape` of `(4, 4, 4, 4, 4, 4)` (with `dimensionality_descriptors=6`)

<img width="639" alt="Screenshot 2022-07-04 at 19 08 17" src="https://user-images.githubusercontent.com/32456875/177203462-23d5ac47-7aba-4614-89be-b84ef1f02c01.png">



Here is some code for testing it:
```python

dimensionality_descriptors = 3
grid_shape = (4, 4, 2)

# dimensionality_descriptors = 6
# grid_shape = (4,) * dimensionality_descriptors

minval = jnp.array([0] * dimensionality_descriptors)
maxval = jnp.array([1] * dimensionality_descriptors)

random_key = jax.random.PRNGKey(seed=0)
random_key, key_desc, key_fit = jax.random.split(random_key, num=3)

number_samples_test = 300
descriptors = jax.random.uniform(key_desc, shape=(number_samples_test, dimensionality_descriptors))
fitnesses = jax.random.uniform(key_fit, shape=(number_samples_test,))
# Uncomment to test with "empty" descriptors
# fitnesses = fitnesses.at[10:].set(-jnp.inf)

repertoire = MapElitesRepertoire(None, fitnesses, descriptors, None)

fig, ax = plot_multidimensional_map_elites_grid(
    repertoire=repertoire,
    minval=minval,
    maxval=maxval,
    grid_shape=grid_shape,
    vmin=0,
    vmax=1,
)
plt.show()

```