### PR TITLE
Update the rules that trigger the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The current CI has redundancies, when a pull request is opened, both push and pull request events are true and the jobs are hence launched two times. 

In this PR, a new rule is suggested. The CI would be triggered when:
- a push is made on develop or main
- a pull request is opened (even as a draft)

Hence, a branch that does not correspond yet to a PR will not trigger any CI action.