### PR TITLE
fix the static argnames of sample in masked repertoire

### DIFF
--- a/qdax/core/containers/mome_repertoire.py
+++ b/qdax/core/containers/mome_repertoire.py
@@ -53,7 +53,7 @@ class MOMERepertoire(MapElitesRepertoire):
         mask: jnp.ndarray,
         random_key: RNGKey,
     ) -> Genotype:
-        """Sample num_samples elements in masked pareto front.
+        """Sample one single genotype in masked pareto front.
 
         Note: do not retrieve a random key because this function
         is to be vmapped. The public method that uses this function


### PR DESCRIPTION
Fix #46 