### PR TITLE
Add 'Open in Colab' link to all example notebooks

### DIFF
--- a/notebooks/cmamega_example.ipynb
+++ b/notebooks/cmamega_example.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/cmamega_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Optimizing with CMA-MEGA in Jax\n",
     "\n",
     "This notebook shows how to use QDax to find diverse and performing parameters on the Rastrigin problem. It can be run locally or on Google Colab. We recommand to use a GPU. This notebook will show:\n",

--- a/notebooks/dads_example.ipynb
+++ b/notebooks/dads_example.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/dads_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Training DADS with Jax\n",
     "\n",
     "This notebook shows how to use QDax to train DADS on a Brax environment. It can be run locally or on Google Colab. We recommand to use a GPU. This notebook will show:\n",

--- a/notebooks/diayn_example.ipynb
+++ b/notebooks/diayn_example.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/diayn_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Training DIAYN with Jax\n",
     "\n",
     "This notebook shows how to use QDax to train DIAYN on a Brax environment. It can be run locally or on Google Colab. We recommand to use a GPU. This notebook will show:\n",

--- a/notebooks/mapelites_example.ipynb
+++ b/notebooks/mapelites_example.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/mapelites_example.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/notebooks/mome_example.ipynb
+++ b/notebooks/mome_example.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "59f748d3",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/mome_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a5e13ff6",
    "metadata": {},
    "source": [

--- a/notebooks/omgmega_example.ipynb
+++ b/notebooks/omgmega_example.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/omgmega_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Optimizing with OMG-MEGA in Jax\n",
     "\n",
     "This notebook shows how to use QDax to find diverse and performing parameters on the Rastrigin problem.\n",

--- a/notebooks/pgame_example.ipynb
+++ b/notebooks/pgame_example.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/pgame_example.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/notebooks/smerl_example.ipynb
+++ b/notebooks/smerl_example.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adaptive-intelligent-robotics/QDax/blob/main/notebooks/smerl_example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Training DIAYN SMERL with Jax\n",
     "\n",
     "This notebook shows how to use QDax to train DIAYN SMERL on a Brax environment. It can be run locally or on Google Colab. We recommand to use a GPU. This notebook will show:\n",


### PR DESCRIPTION
This PR just adds the 'Open in Colab' to the top of all the example notebooks to make it easier to run the code.