### PR TITLE
Fix reset_based scoring usage in brax env default definition function

### DIFF
--- a/qdax/tasks/brax_envs.py
+++ b/qdax/tasks/brax_envs.py
@@ -244,7 +244,7 @@ def create_brax_scoring_fn(
             evaluation episodes. If None, we use create_policy_network_play_step_fn
             to generate it.
         episode_length: The maximal episode length.
-        deterministic: Whether we reset the initial state of the robot to the same 
+        deterministic: Whether we reset the initial state of the robot to the same
             deterministic init_state or if we use the reset() function of the env.
         play_reset_fn: the function used to reset the environment to an initial state.
             Only used if deterministic is False. If None, we take env.reset as
@@ -267,6 +267,7 @@ def create_brax_scoring_fn(
         # Define the function to deterministically reset the environment
         def deterministic_reset(key: RNGKey, init_state: EnvState) -> EnvState:
             return init_state
+
         play_reset_fn = partial(deterministic_reset, init_state=init_state)
 
     # Stochastic case
@@ -304,7 +305,7 @@ def create_default_brax_task_components(
         random_key: Jax random key
         episode_length: The maximal rollout length.
         mlp_policy_hidden_layer_sizes: Hidden layer sizes of the policy network.
-        deterministic: Whether we reset the initial state of the robot to the same 
+        deterministic: Whether we reset the initial state of the robot to the same
             deterministic init_state or if we use the reset() function of the env.
 
     Returns:

--- a/qdax/tasks/brax_envs.py
+++ b/qdax/tasks/brax_envs.py
@@ -218,7 +218,6 @@ def reset_based_scoring_function_brax_envs(
 def create_brax_scoring_fn(
     env: brax.envs.Env,
     policy_network: nn.Module,
-    batch_size: int,
     bd_extraction_fn: Callable[[QDTransition, jnp.ndarray], Descriptor],
     random_key: RNGKey,
     play_step_fn: Optional[
@@ -227,7 +226,7 @@ def create_brax_scoring_fn(
         ]
     ] = None,
     episode_length: int = 100,
-    is_reset_based: bool = False,
+    deterministic: bool = True,
     play_reset_fn: Optional[Callable[[RNGKey], EnvState]] = None,
 ) -> Tuple[
     Callable[[Genotype, RNGKey], Tuple[Fitness, Descriptor, ExtraScores, RNGKey]],
@@ -239,17 +238,16 @@ def create_brax_scoring_fn(
     Args:
         env: The BRAX environment.
         policy_network: The policy network controller.
-        batch_size: the number of environments we play simultaneously.
         bd_extraction_fn: The behaviour descriptor extraction function.
         random_key: a random key used for stochastic operations.
         play_step_fn: the function used to perform environment rollouts and collect
             evaluation episodes. If None, we use create_policy_network_play_step_fn
             to generate it.
         episode_length: The maximal episode length.
-        is_reset_based: Whether we reset the initial state of the robot before each
-            evaluation or not.
+        deterministic: Whether we reset the initial state of the robot to the same 
+            deterministic init_state or if we use the reset() function of the env.
         play_reset_fn: the function used to reset the environment to an initial state.
-            Only used if is_reset_based is True. If None, we take env.reset as
+            Only used if deterministic is False. If None, we take env.reset as
             default reset function.
 
     Returns:
@@ -259,42 +257,39 @@ def create_brax_scoring_fn(
     """
     if play_step_fn is None:
         play_step_fn = create_policy_network_play_step_fn(env, policy_network)
-    if play_reset_fn is None:
-        play_reset_fn = env.reset
 
-    if not is_reset_based:
+    # Deterministic case
+    if deterministic:
         # Create the initial environment states
         random_key, subkey = jax.random.split(random_key)
-        keys = jnp.repeat(jnp.expand_dims(subkey, axis=0), repeats=batch_size, axis=0)
-        reset_fn = jax.jit(jax.vmap(env.reset))
-        init_states = reset_fn(keys)
+        init_state = env.reset(subkey)
 
-        scoring_fn = functools.partial(
-            scoring_function_brax_envs,
-            init_states=init_states,
-            episode_length=episode_length,
-            play_step_fn=play_step_fn,
-            behavior_descriptor_extractor=bd_extraction_fn,
-        )
-    else:
-        scoring_fn = functools.partial(
-            reset_based_scoring_function_brax_envs,
-            episode_length=episode_length,
-            play_reset_fn=play_reset_fn,
-            play_step_fn=play_step_fn,
-            behavior_descriptor_extractor=bd_extraction_fn,
-        )
+        # Define the function to deterministically reset the environment
+        def deterministic_reset(key: RNGKey, init_state: EnvState) -> EnvState:
+            return init_state
+        play_reset_fn = partial(deterministic_reset, init_state=init_state)
+
+    # Stochastic case
+    elif play_reset_fn is None:
+        play_reset_fn = env.reset
+
+    scoring_fn = functools.partial(
+        reset_based_scoring_function_brax_envs,
+        episode_length=episode_length,
+        play_reset_fn=play_reset_fn,
+        play_step_fn=play_step_fn,
+        behavior_descriptor_extractor=bd_extraction_fn,
+    )
 
     return scoring_fn, random_key
 
 
 def create_default_brax_task_components(
     env_name: str,
-    batch_size: int,
     random_key: RNGKey,
     episode_length: int = 100,
     mlp_policy_hidden_layer_sizes: Tuple[int, ...] = (64, 64),
-    is_reset_based: bool = False,
+    deterministic: bool = True,
 ) -> Tuple[
     brax.envs.Env,
     MLP,
@@ -306,12 +301,11 @@ def create_default_brax_task_components(
 
     Args:
         env_name: Name of the BRAX environment (e.g. "ant_omni", "walker2d_uni"...).
-        batch_size: The number of environments we play simultaneously.
         random_key: Jax random key
         episode_length: The maximal rollout length.
         mlp_policy_hidden_layer_sizes: Hidden layer sizes of the policy network.
-        is_reset_based: Whether we reset the initial state of the robot before each
-            evaluation or not.
+        deterministic: Whether we reset the initial state of the robot to the same 
+            deterministic init_state or if we use the reset() function of the env.
 
     Returns:
         env: The BRAX environment.
@@ -336,11 +330,10 @@ def create_default_brax_task_components(
     scoring_fn, random_key = create_brax_scoring_fn(
         env,
         policy_network,
-        batch_size,
         bd_extraction_fn,
         random_key,
         episode_length=episode_length,
-        is_reset_based=is_reset_based,
+        deterministic=deterministic,
     )
 
     return env, policy_network, scoring_fn, random_key

--- a/tests/default_tasks_test/brax_task_test.py
+++ b/tests/default_tasks_test/brax_task_test.py
@@ -38,7 +38,6 @@ def test_map_elites(env_name: str, batch_size: int, is_task_reset_based: bool) -
 
     env, policy_network, scoring_fn, random_key = create_default_brax_task_components(
         env_name=env_name,
-        batch_size=batch_size,
         random_key=random_key,
     )
 


### PR DESCRIPTION
This PR aims to fix the way the reset_based scoring function is used in the `create_default_brax_task_components` function, which allows the creation of a default Brax environment.

The reset_based scoring function takes as input a reset function `play_reset_fn`and thus allows to define either deterministic or stochastic tasks. However, it has a second advantage compared to the usual scoring function: as it vmap the `play_reset_fn`, it works with any dimension of genotype to evaluate. Unlike the default scoring function that can only evaluate a fixed number of genotypes (of the same size as the init_states given as input). 

The current `create_default_brax_task_components` takes as input a boolean `is_reset_based` and depending on it returns either the default scoring function or the reset_based scoring function. This commit uniformises this with the following changes:
- instead of an `is_reset_based` boolean, use a `deterministic` boolean (`True` by default) to set up either a deterministic or stochastic environment.
- use the reset_based scoring function in both cases, so the scoring is scalable to any batch-size.
- remove the batch-size from the inputs as this is not used anymore, making this function more general.