### PR TITLE
Fix/docs ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     - id: black
       language_version: python3.8
       args: ["--target-version", "py38"]
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.8.4
     hooks:
     - id: flake8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,6 @@ mkdocs==1.2.3
 mkdocs-autorefs==0.3.1
 mkdocs-git-revision-date-plugin==0.3.1
 mkdocs-material==8.2.3
-mkdocstrings==0.18.1
+mkdocstrings==0.19
 mknotebooks==0.7.1
 pytkdocs==0.16.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,8 @@ mkdocs==1.2.3
 mkdocs-autorefs==0.3.1
 mkdocs-git-revision-date-plugin==0.3.1
 mkdocs-material==8.2.3
+mkdocs-material-extensions==1.1.1
 mkdocstrings==0.19
+mkdocstrings-python-legacy==0.2.3
 mknotebooks==0.7.1
 pytkdocs==0.16.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ mkdocs-git-revision-date-plugin==0.3.1
 mkdocs-material==8.2.3
 mkdocstrings==0.18.1
 mknotebooks==0.7.1
+pytkdocs==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 absl-py==1.0.0
 brax==0.0.15
-chex==0.1.4
+chex==0.1.5
 dm-haiku==0.0.5
 flax==0.6.0
 gym==0.23.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "absl-py>=1.0.0",
         "jax>=0.3.16",
         "jaxlib>=0.3.15",  # necessary to build the doc atm
-        "flax>=0.6",
+        "flax>=0.6, <0.6.2",
         "brax>=0.0.15",
         "gym>=0.23.1",
         "numpy>=1.22.3",


### PR DESCRIPTION
In the docs building, setup.py overrides some dependencies from requirements. In this case, flax was updated to 0.6.2 where a change has been introduced to PyTreeNode, causing the issue when a class inheriting from PyTreeNode was parsed for auto-docstrings.

Was also necessary to ping other mkdocstrings dependencies.

Should be fixed now. [Issue opened in flax](https://github.com/google/flax/issues/2648) to have more information about their recent change.