### PR TITLE
fix: sampling_test incorrect naming

### DIFF
--- a/tests/utils_test/sampling_test.py
+++ b/tests/utils_test/sampling_test.py
@@ -90,8 +90,8 @@ def test_sampling() -> None:
     )
 
     # Evaluate individuals using the scoring functions
-    descriptors, fitnesses, _, _ = scoring_fn(init_variables, random_key)
-    sample_descriptors, sample_fitnesses, _, _ = scoring_1_sample_fn(
+    fitnesses, descriptors, _, _ = scoring_fn(init_variables, random_key)
+    sample_fitnesses, sample_descriptors, _, _ = scoring_1_sample_fn(
         init_variables, random_key
     )
 
@@ -107,7 +107,7 @@ def test_sampling() -> None:
     )
 
     # Evaluate individuals using the scoring functions
-    sample_descriptors, sample_fitnesses, _, _ = scoring_multi_sample_fn(
+    sample_fitnesses, sample_descriptors, _, _ = scoring_multi_sample_fn(
         init_variables, random_key
     )
 


### PR DESCRIPTION
Fix `sampling_test.py`, in which the name of fitnesses and descriptors are inverted. The test is still correct, this is only a naming issue. 