### PR TITLE
fix: run-image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -168,5 +168,4 @@ cython_debug/
 .gitignore
 Makefile
 mypy.ini
-README.md
 dev.Dockerfile

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -93,6 +93,7 @@ FROM cuda-image as run-image
 
 COPY qdax qdax
 COPY setup.py ./
+COPY README.md ./
 
 RUN pip install .
 


### PR DESCRIPTION
This PR fixes the `run-image` of the `dev.Dockerfile` by copying the` README.md `into the docker container (which requires removing `README.md` from the `.dockerignore`). Closes #96.