### PR TITLE
Fix state descriptors in case fixed init states are used

### DIFF
--- a/qdax/environments/__init__.py
+++ b/qdax/environments/__init__.py
@@ -126,23 +126,31 @@ def create(
     elif env_name in _qdax_custom_envs.keys():
         base_env_name = _qdax_custom_envs[env_name]["env"]
         env = brax.envs._envs[base_env_name](legacy_spring=True, **kwargs)
+    else:
+        raise NotImplementedError("This environment name does not exist!")
 
+    if env_name in _qdax_custom_envs.keys():
         # roll with qdax wrappers
         wrappers = _qdax_custom_envs[env_name]["wrappers"]
         if qdax_wrappers_kwargs is None:
             kwargs_list = _qdax_custom_envs[env_name]["kwargs"]
         else:
             kwargs_list = qdax_wrappers_kwargs
-
         for wrapper, kwargs in zip(wrappers, kwargs_list):  # type: ignore
             env = wrapper(env, base_env_name, **kwargs)  # type: ignore
-    else:
-        raise NotImplementedError("This environment name does not exist!")
 
     if episode_length is not None:
         env = brax.envs.wrappers.EpisodeWrapper(env, episode_length, action_repeat)
     if batch_size:
         env = brax.envs.wrappers.VectorWrapper(env, batch_size)
+    if fixed_init_state:
+        # retrieve the base env
+        if env_name not in _qdax_custom_envs.keys():
+            base_env_name = env_name
+        # wrap the env
+        env = FixedInitialStateWrapper(
+            env, base_env_name=base_env_name
+        )
     if auto_reset:
         env = brax.envs.wrappers.AutoResetWrapper(env)
         if env_name in _qdax_custom_envs.keys():
@@ -150,19 +158,6 @@ def create(
     if eval_metrics:
         env = brax.envs.wrappers.EvalWrapper(env)
         env = CompletedEvalWrapper(env)
-    if fixed_init_state:
-        # retrieve the base env
-        if env_name in _qdax_custom_envs.keys():
-            base_env_name_fixed_state_wrapper: str = _qdax_custom_envs[  # type: ignore
-                env_name
-            ]["env"]
-        else:
-            base_env_name_fixed_state_wrapper = env_name
-
-        # wrap the env
-        env = FixedInitialStateWrapper(
-            env, base_env_name=base_env_name_fixed_state_wrapper
-        )
 
     return env
 


### PR DESCRIPTION
Fix the order in which we are applying the wrappers to make sure that state descriptors are in line with fixed init states.

Without this modification, FixedInitialStateWrapper is overwriting state.obs without changing the state descriptor accordingly.