### PR TITLE
switched depreciated dependency sklearn -> scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ protobuf==3.19.4
 scikit-learn==1.0.2
 scipy==1.8.0
 seaborn==0.11.2
-sklearn==0.0
+scikit-learn==1.0.2
 tensorflow-probability==0.15.0
 typing-extensions==4.3.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "numpy>=1.22.3",
         "scikit-learn>=1.0.2",
         "scipy>=1.8.0",
-        "sklearn",
+        "scikit-learn",
     ],
     dependency_links=[
         "https://storage.googleapis.com/jax-releases/jax_releases.html",


### PR DESCRIPTION
switched depreciated dependency sklearn -> scikit-learn

Related issues: #130

The PR replaces the depreciated `sklearn` package with `scikit-learn`.

## Checks

- [x] a clear description of the PR has been added
- [ ] sufficient tests have been written
- [ ] relevant section added to the documentation
- [ ] example notebook added to the repo
- [ ] clean docstrings and comments have been written
- [ ] if any issue/observation has been discovered, a new issue has been opened

## Future improvements

N/A