### PR TITLE
Hotfix/scikit learn requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ jupyter
 numpy==1.22.3
 protobuf==3.19.4
 scikit-learn==1.0.2
-scikit-learn==1.0.2
 scipy==1.8.0
 seaborn==0.11.2
 tensorflow-probability==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ jupyter
 numpy==1.22.3
 protobuf==3.19.4
 scikit-learn==1.0.2
+scikit-learn==1.0.2
 scipy==1.8.0
 seaborn==0.11.2
-scikit-learn==1.0.2
 tensorflow-probability==0.15.0
 typing-extensions==4.3.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "numpy>=1.22.3",
         "scikit-learn>=1.0.2",
         "scipy>=1.8.0",
-        "scikit-learn",
     ],
     dependency_links=[
         "https://storage.googleapis.com/jax-releases/jax_releases.html",


### PR DESCRIPTION
Copy from #131 

switched depreciated dependency sklearn -> scikit-learn

Related issues: #130

The PR replaces the depreciated `sklearn` package with `scikit-learn`.

## Checks

- [x] a clear description of the PR has been added
- [x] sufficient tests have been written
- [x] relevant section added to the documentation
- [x] example notebook added to the repo
- [x] clean docstrings and comments have been written
- [x] if any issue/observation has been discovered, a new issue has been opened

## Future improvements

N/A