### PR TITLE
DCG-MAP-Elites

### DIFF
--- a/qdax/core/emitters/cma_emitter.py
+++ b/qdax/core/emitters/cma_emitter.py
@@ -99,14 +99,20 @@ class CMAEmitter(Emitter, ABC):
 
     @partial(jax.jit, static_argnames=("self",))
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[CMAEmitterState, RNGKey]:
         """
         Initializes the CMA-MEGA emitter
 
 
         Args:
-            init_genotypes: initial genotypes to add to the grid.
+            genotypes: initial genotypes to add to the grid.
             random_key: a random key to handle stochastic operations.
 
         Returns:
@@ -154,7 +160,7 @@ class CMAEmitter(Emitter, ABC):
             cmaes_state=emitter_state.cmaes_state, random_key=random_key
         )
 
-        return offsprings, random_key
+        return offsprings, {}, random_key
 
     @partial(
         jax.jit,

--- a/qdax/core/emitters/cma_mega_emitter.py
+++ b/qdax/core/emitters/cma_mega_emitter.py
@@ -100,14 +100,20 @@ class CMAMEGAEmitter(Emitter):
 
     @partial(jax.jit, static_argnames=("self",))
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[CMAMEGAState, RNGKey]:
         """
         Initializes the CMA-MEGA emitter.
 
 
         Args:
-            init_genotypes: initial genotypes to add to the grid.
+            genotypes: initial genotypes to add to the grid.
             random_key: a random key to handle stochastic operations.
 
         Returns:
@@ -117,7 +123,7 @@ class CMAMEGAEmitter(Emitter):
         # define init theta as 0
         theta = jax.tree_util.tree_map(
             lambda x: jnp.zeros_like(x[:1, ...]),
-            init_genotypes,
+            genotypes,
         )
 
         # score it
@@ -181,7 +187,7 @@ class CMAMEGAEmitter(Emitter):
         # Compute new candidates
         new_thetas = jax.tree_util.tree_map(lambda x, y: x + y, theta, update_grad)
 
-        return new_thetas, random_key
+        return new_thetas, {}, random_key
 
     @partial(
         jax.jit,

--- a/qdax/core/emitters/cma_pool_emitter.py
+++ b/qdax/core/emitters/cma_pool_emitter.py
@@ -49,14 +49,20 @@ class CMAPoolEmitter(Emitter):
 
     @partial(jax.jit, static_argnames=("self",))
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[CMAPoolEmitterState, RNGKey]:
         """
         Initializes the CMA-MEGA emitter
 
 
         Args:
-            init_genotypes: initial genotypes to add to the grid.
+            genotypes: initial genotypes to add to the grid.
             random_key: a random key to handle stochastic operations.
 
         Returns:
@@ -67,7 +73,7 @@ class CMAPoolEmitter(Emitter):
             carry: RNGKey, unused: Any
         ) -> Tuple[RNGKey, CMAEmitterState]:
             random_key = carry
-            emitter_state, random_key = self._emitter.init(init_genotypes, random_key)
+            emitter_state, random_key = self._emitter.init(genotypes, random_key)
             return random_key, emitter_state
 
         # init all the emitter states
@@ -115,7 +121,7 @@ class CMAPoolEmitter(Emitter):
             repertoire, used_emitter_state, random_key
         )
 
-        return offsprings, random_key
+        return offsprings, {}, random_key
 
     @partial(
         jax.jit,

--- a/qdax/core/emitters/dcg_me_emitter.py
+++ b/qdax/core/emitters/dcg_me_emitter.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import flax.linen as nn
+
+from qdax.core.emitters.multi_emitter import MultiEmitter
+from qdax.core.emitters.qdcg_emitter import QualityDCGConfig, QualityDCGEmitter
+from qdax.core.emitters.standard_emitters import MixingEmitter
+from qdax.environments.base_wrappers import QDEnv
+from qdax.types import Params, RNGKey
+
+
+@dataclass
+class DCGMEConfig:
+    """Configuration for DCGME Algorithm"""
+
+    ga_batch_size: int = 128
+    qpg_batch_size: int = 64
+    ai_batch_size: int = 64
+    lengthscale: float = 0.1
+
+    # PG emitter
+    critic_hidden_layer_size: Tuple[int, ...] = (256, 256)
+    num_critic_training_steps: int = 3000
+    num_pg_training_steps: int = 150
+    batch_size: int = 100
+    replay_buffer_size: int = 1_000_000
+    discount: float = 0.99
+    reward_scaling: float = 1.0
+    critic_learning_rate: float = 3e-4
+    actor_learning_rate: float = 3e-4
+    policy_learning_rate: float = 1e-3
+    noise_clip: float = 0.5
+    policy_noise: float = 0.2
+    soft_tau_update: float = 0.005
+    policy_delay: int = 2
+
+
+class DCGMEEmitter(MultiEmitter):
+    def __init__(
+        self,
+        config: DCGMEConfig,
+        policy_network: nn.Module,
+        actor_network: nn.Module,
+        env: QDEnv,
+        variation_fn: Callable[[Params, Params, RNGKey], Tuple[Params, RNGKey]],
+    ) -> None:
+        self._config = config
+        self._env = env
+        self._variation_fn = variation_fn
+
+        qdcg_config = QualityDCGConfig(
+            qpg_batch_size=config.qpg_batch_size,
+            ai_batch_size=config.ai_batch_size,
+            lengthscale=config.lengthscale,
+            critic_hidden_layer_size=config.critic_hidden_layer_size,
+            num_critic_training_steps=config.num_critic_training_steps,
+            num_pg_training_steps=config.num_pg_training_steps,
+            batch_size=config.batch_size,
+            replay_buffer_size=config.replay_buffer_size,
+            discount=config.discount,
+            reward_scaling=config.reward_scaling,
+            critic_learning_rate=config.critic_learning_rate,
+            actor_learning_rate=config.actor_learning_rate,
+            policy_learning_rate=config.policy_learning_rate,
+            noise_clip=config.noise_clip,
+            policy_noise=config.policy_noise,
+            soft_tau_update=config.soft_tau_update,
+            policy_delay=config.policy_delay,
+        )
+
+        # define the quality emitter
+        q_emitter = QualityDCGEmitter(
+            config=qdcg_config,
+            policy_network=policy_network,
+            actor_network=actor_network,
+            env=env
+        )
+
+        # define the GA emitter
+        ga_emitter = MixingEmitter(
+            mutation_fn=lambda x, r: (x, r),
+            variation_fn=variation_fn,
+            variation_percentage=1.0,
+            batch_size=config.ga_batch_size,
+        )
+
+        super().__init__(emitters=(q_emitter, ga_emitter))

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -10,7 +10,7 @@ import jax
 import optax
 
 from qdax.core.containers.archive import Archive
-from qdax.core.containers.repertoire import Repertoire
+from qdax.core.containers.repertoire import MapElitesRepertoire
 from qdax.core.emitters.qpg_emitter import (
     QualityPGConfig,
     QualityPGEmitter,
@@ -77,12 +77,18 @@ class DiversityPGEmitter(QualityPGEmitter):
         self._score_novelty = score_novelty
 
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[DiversityPGEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
-            init_genotypes: The initial population.
+            genotypes: The initial population.
             random_key: A random key.
 
         Returns:
@@ -90,7 +96,7 @@ class DiversityPGEmitter(QualityPGEmitter):
         """
 
         # init elements of diversity emitter state with QualityEmitterState.init()
-        diversity_emitter_state, random_key = super().init(init_genotypes, random_key)
+        diversity_emitter_state, random_key = super().init(genotypes, random_key)
 
         # store elements in a dictionary
         attributes_dict = vars(diversity_emitter_state)
@@ -116,7 +122,7 @@ class DiversityPGEmitter(QualityPGEmitter):
     def state_update(
         self,
         emitter_state: DiversityPGEmitterState,
-        repertoire: Optional[Repertoire],
+        repertoire: Optional[MapElitesRepertoire],
         genotypes: Optional[Genotype],
         fitnesses: Optional[Fitness],
         descriptors: Optional[Descriptor],

--- a/qdax/core/emitters/emitter.py
+++ b/qdax/core/emitters/emitter.py
@@ -30,7 +30,13 @@ class EmitterState(PyTreeNode):
 
 class Emitter(ABC):
     def init(
-        self, init_genotypes: Optional[Genotype], random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: Repertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[Optional[EmitterState], RNGKey]:
         """Initialises the state of the emitter. Some emitters do
         not need a state, in which case, the value None can be

--- a/qdax/core/emitters/mees_emitter.py
+++ b/qdax/core/emitters/mees_emitter.py
@@ -236,26 +236,32 @@ class MEESEmitter(Emitter):
         static_argnames=("self",),
     )
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[MEESEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
-            init_genotypes: The initial population.
+            genotypes: The initial population.
             random_key: A random key.
 
         Returns:
             The initial state of the MEESEmitter, a new random key.
         """
         # Initialisation requires one initial genotype
-        if jax.tree_util.tree_leaves(init_genotypes)[0].shape[0] > 1:
-            init_genotypes = jax.tree_util.tree_map(
+        if jax.tree_util.tree_leaves(genotypes)[0].shape[0] > 1:
+            genotypes = jax.tree_util.tree_map(
                 lambda x: x[0],
-                init_genotypes,
+                genotypes,
             )
 
         # Initialise optimizer
-        initial_optimizer_state = self._optimizer.init(init_genotypes)
+        initial_optimizer_state = self._optimizer.init(genotypes)
 
         # Create empty Novelty archive
         if self._config.use_explore:
@@ -270,7 +276,7 @@ class MEESEmitter(Emitter):
         # Create empty updated genotypes and fitness
         last_updated_genotypes = jax.tree_util.tree_map(
             lambda x: jnp.zeros(shape=(self._config.last_updated_size,) + x.shape[1:]),
-            init_genotypes,
+            genotypes,
         )
         last_updated_fitnesses = -jnp.inf * jnp.ones(
             shape=self._config.last_updated_size
@@ -280,7 +286,7 @@ class MEESEmitter(Emitter):
             MEESEmitterState(
                 initial_optimizer_state=initial_optimizer_state,
                 optimizer_state=initial_optimizer_state,
-                offspring=init_genotypes,
+                offspring=genotypes,
                 generation_count=0,
                 novelty_archive=novelty_archive,
                 last_updated_genotypes=last_updated_genotypes,
@@ -313,7 +319,7 @@ class MEESEmitter(Emitter):
             a new jax PRNG key
         """
 
-        return emitter_state.offspring, random_key
+        return emitter_state.offspring, {}, random_key
 
     @partial(
         jax.jit,

--- a/qdax/core/emitters/multi_emitter.py
+++ b/qdax/core/emitters/multi_emitter.py
@@ -56,13 +56,19 @@ class MultiEmitter(Emitter):
         return tuple(indexes_separation_batches)
 
     def init(
-        self, init_genotypes: Optional[Genotype], random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: Repertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[Optional[EmitterState], RNGKey]:
         """
         Initialize the state of the emitter.
 
         Args:
-            init_genotypes: The genotypes of the initial population.
+            genotypes: The genotypes of the initial population.
             random_key: a random key to handle stochastic operations.
 
         Returns:
@@ -76,7 +82,7 @@ class MultiEmitter(Emitter):
         # init all emitter states - gather them
         emitter_states = []
         for emitter, subkey_emitter in zip(self.emitters, subkeys):
-            emitter_state, _ = emitter.init(init_genotypes, subkey_emitter)
+            emitter_state, _ = emitter.init(subkey_emitter, repertoire, genotypes, fitnesses, descriptors, extra_scores)
             emitter_states.append(emitter_state)
 
         return MultiEmitterState(tuple(emitter_states)), random_key
@@ -108,21 +114,23 @@ class MultiEmitter(Emitter):
 
         # emit from all emitters and gather offsprings
         all_offsprings = []
+        all_extra_info = {}
         for emitter, sub_emitter_state, subkey_emitter in zip(
             self.emitters,
             emitter_state.emitter_states,
             subkeys,
         ):
-            genotype, _ = emitter.emit(repertoire, sub_emitter_state, subkey_emitter)
+            genotype, extra_info, _ = emitter.emit(repertoire, sub_emitter_state, subkey_emitter)
             batch_size = jax.tree_util.tree_leaves(genotype)[0].shape[0]
             assert batch_size == emitter.batch_size
             all_offsprings.append(genotype)
+            all_extra_info = all_extra_info | extra_info
 
         # concatenate offsprings together
         offsprings = jax.tree_util.tree_map(
             lambda *x: jnp.concatenate(x, axis=0), *all_offsprings
         )
-        return offsprings, random_key
+        return offsprings, all_extra_info, random_key
 
     @partial(jax.jit, static_argnames=("self",))
     def state_update(

--- a/qdax/core/emitters/omg_mega_emitter.py
+++ b/qdax/core/emitters/omg_mega_emitter.py
@@ -84,20 +84,26 @@ class OMGMEGAEmitter(Emitter):
         self._num_descriptors = num_descriptors
 
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: MapElitesRepertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[OMGMEGAEmitterState, RNGKey]:
         """Initialises the state of the emitter. Creates an empty repertoire
         that will later contain the gradients of the individuals.
 
         Args:
-            init_genotypes: The genotypes of the initial population.
+            genotypes: The genotypes of the initial population.
             random_key: a random key to handle stochastic operations.
 
         Returns:
             The initial emitter state.
         """
         # retrieve one genotype from the population
-        first_genotype = jax.tree_util.tree_map(lambda x: x[0], init_genotypes)
+        first_genotype = jax.tree_util.tree_map(lambda x: x[0], genotypes)
 
         # add a dimension of size num descriptors + 1
         gradient_genotype = jax.tree_util.tree_map(
@@ -190,7 +196,7 @@ class OMGMEGAEmitter(Emitter):
             lambda x, y: x + y, genotypes, update_grad
         )
 
-        return new_genotypes, random_key
+        return new_genotypes, {}, random_key
 
     @partial(
         jax.jit,

--- a/qdax/core/emitters/pbt_me_emitter.py
+++ b/qdax/core/emitters/pbt_me_emitter.py
@@ -91,12 +91,18 @@ class PBTEmitter(Emitter):
         )
 
     def init(
-        self, init_genotypes: Genotype, random_key: RNGKey
+        self,
+        random_key: RNGKey,
+        repertoire: Repertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
+        extra_scores: ExtraScores,
     ) -> Tuple[PBTEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
-            init_genotypes: The initial population.
+            genotypes: The initial population.
             random_key: A random key.
 
         Returns:
@@ -145,13 +151,13 @@ class PBTEmitter(Emitter):
 
         # Create emitter state
         # keep only pg population size training states if more are provided
-        init_genotypes = jax.tree_util.tree_map(
-            lambda x: x[: self._config.pg_population_size_per_device], init_genotypes
+        genotypes = jax.tree_util.tree_map(
+            lambda x: x[: self._config.pg_population_size_per_device], genotypes
         )
         emitter_state = PBTEmitterState(
             replay_buffers=replay_buffers,
             env_states=env_states,
-            training_states=init_genotypes,
+            training_states=genotypes,
             random_key=subkey2,
         )
 
@@ -199,7 +205,7 @@ class PBTEmitter(Emitter):
         else:
             genotypes = x_mutation_pg
 
-        return genotypes, random_key
+        return genotypes, {}, random_key
 
     @property
     def batch_size(self) -> int:

--- a/qdax/core/emitters/qdcg_emitter.py
+++ b/qdax/core/emitters/qdcg_emitter.py
@@ -1,54 +1,54 @@
-"""Implements the PG Emitter from PGA-ME algorithm in jax for brax environments,
-based on:
-https://hal.archives-ouvertes.fr/hal-03135723v2/file/PGA_MAP_Elites_GECCO.pdf
+"""Implements the PG Emitter and Actor Injection from DCG-ME algorithm in JAX for Brax environments.
 """
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Callable
 
-import flax.linen as nn
 import jax
-import optax
 from jax import numpy as jnp
+import flax.linen as nn
+from flax.core.frozen_dict import freeze
+import optax
 
-from qdax.core.containers.repertoire import MapElitesRepertoire
+from qdax.core.containers.repertoire import Repertoire
 from qdax.core.emitters.emitter import Emitter, EmitterState
-from qdax.core.neuroevolution.buffers.buffer import QDTransition, ReplayBuffer
-from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_fn
-from qdax.core.neuroevolution.networks.networks import QModule
+from qdax.core.neuroevolution.buffers.buffer import DCGTransition, ReplayBuffer
+from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_dc_fn
+from qdax.core.neuroevolution.networks.networks import QModuleDC
 from qdax.environments.base_wrappers import QDEnv
 from qdax.types import Descriptor, ExtraScores, Fitness, Genotype, Params, RNGKey
 
 
 @dataclass
-class QualityPGConfig:
-    """Configuration for QualityPG Emitter"""
+class QualityDCGConfig:
+    """Configuration for QualityDCG Emitter"""
 
-    env_batch_size: int = 100
-    num_critic_training_steps: int = 300
-    num_pg_training_steps: int = 100
+    qpg_batch_size: int = 64
+    ai_batch_size: int = 64
+    lengthscale: float = 0.1
 
-    # TD3 params
-    replay_buffer_size: int = 1000000
     critic_hidden_layer_size: Tuple[int, ...] = (256, 256)
+    num_critic_training_steps: int = 3000
+    num_pg_training_steps: int = 150
+    batch_size: int = 100
+    replay_buffer_size: int = 1_000_000
+    discount: float = 0.99
+    reward_scaling: float = 1.0
     critic_learning_rate: float = 3e-4
     actor_learning_rate: float = 3e-4
     policy_learning_rate: float = 1e-3
     noise_clip: float = 0.5
     policy_noise: float = 0.2
-    discount: float = 0.99
-    reward_scaling: float = 1.0
-    batch_size: int = 256
     soft_tau_update: float = 0.005
     policy_delay: int = 2
 
 
-class QualityPGEmitterState(EmitterState):
+class QualityDCGEmitterState(EmitterState):
     """Contains training state for the learner."""
 
     critic_params: Params
-    critic_optimizer_state: optax.OptState
+    critic_opt_state: optax.OptState
     actor_params: Params
     actor_opt_state: optax.OptState
     target_critic_params: Params
@@ -58,7 +58,7 @@ class QualityPGEmitterState(EmitterState):
     steps: jnp.ndarray
 
 
-class QualityPGEmitter(Emitter):
+class QualityDCGEmitter(Emitter):
     """
     A policy gradient emitter used to implement the Policy Gradient Assisted MAP-Elites
     (PGA-Map-Elites) algorithm.
@@ -66,23 +66,26 @@ class QualityPGEmitter(Emitter):
 
     def __init__(
         self,
-        config: QualityPGConfig,
+        config: QualityDCGConfig,
         policy_network: nn.Module,
+        actor_network: nn.Module,
         env: QDEnv,
     ) -> None:
         self._config = config
         self._env = env
         self._policy_network = policy_network
+        self._actor_network = actor_network
 
         # Init Critics
-        critic_network = QModule(
+        critic_network = QModuleDC(
             n_critics=2, hidden_layer_sizes=self._config.critic_hidden_layer_size
         )
         self._critic_network = critic_network
 
         # Set up the losses and optimizers - return the opt states
-        self._policy_loss_fn, self._critic_loss_fn = make_td3_loss_fn(
+        self._policy_loss_fn, self._actor_loss_fn, self._critic_loss_fn = make_td3_loss_dc_fn(
             policy_fn=policy_network.apply,
+            actor_fn=actor_network.apply,
             critic_fn=critic_network.apply,
             reward_scaling=self._config.reward_scaling,
             discount=self._config.discount,
@@ -107,7 +110,7 @@ class QualityPGEmitter(Emitter):
         Returns:
             the batch size emitted by the emitter.
         """
-        return self._config.env_batch_size
+        return self._config.qpg_batch_size + self._config.ai_batch_size
 
     @property
     def use_all_data(self) -> bool:
@@ -121,12 +124,12 @@ class QualityPGEmitter(Emitter):
     def init(
         self,
         random_key: RNGKey,
-        repertoire: MapElitesRepertoire,
+        repertoire: Repertoire,
         genotypes: Genotype,
         fitnesses: Fitness,
         descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> Tuple[QualityPGEmitterState, RNGKey]:
+    ) -> Tuple[QualityDCGEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
@@ -137,29 +140,33 @@ class QualityPGEmitter(Emitter):
             The initial state of the PGAMEEmitter, a new random key.
         """
 
-        observation_size = self._env.observation_size
+        observation_size = jax.tree_util.tree_leaves(genotypes)[1].shape[1]
+        descriptor_size = self._env.behavior_descriptor_length
         action_size = self._env.action_size
-        descriptor_size = self._env.state_descriptor_length
 
         # Initialise critic, greedy actor and population
         random_key, subkey = jax.random.split(random_key)
         fake_obs = jnp.zeros(shape=(observation_size,))
+        fake_desc = jnp.zeros(shape=(descriptor_size,))
         fake_action = jnp.zeros(shape=(action_size,))
+
         critic_params = self._critic_network.init(
-            subkey, obs=fake_obs, actions=fake_action
+            subkey, obs=fake_obs, actions=fake_action, desc=fake_desc
         )
         target_critic_params = jax.tree_util.tree_map(lambda x: x, critic_params)
 
-        actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
-        target_actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
+        random_key, subkey = jax.random.split(random_key)
+        actor_params = self._actor_network.init(
+            subkey, obs=fake_obs, desc=fake_desc)
+        target_actor_params = jax.tree_util.tree_map(lambda x: x, actor_params)
 
         # Prepare init optimizer states
-        critic_optimizer_state = self._critic_optimizer.init(critic_params)
-        actor_optimizer_state = self._actor_optimizer.init(actor_params)
+        critic_opt_state = self._critic_optimizer.init(critic_params)
+        actor_opt_state = self._actor_optimizer.init(actor_params)
 
         # Initialize replay buffer
-        dummy_transition = QDTransition.init_dummy(
-            observation_dim=observation_size,
+        dummy_transition = DCGTransition.init_dummy(
+            observation_dim=self._env.observation_size,
             action_dim=action_size,
             descriptor_dim=descriptor_size,
         )
@@ -168,30 +175,81 @@ class QualityPGEmitter(Emitter):
             buffer_size=self._config.replay_buffer_size, transition=dummy_transition
         )
 
+        assert "transitions" in extra_scores.keys(), "Missing transitions or wrong key"
+        transitions = extra_scores["transitions"]
+        episode_length = transitions.obs.shape[1]
+
+        desc = jnp.repeat(descriptors[:, jnp.newaxis, :], episode_length, axis=1)
+        desc_normalized = jax.vmap(jax.vmap(self._normalize_desc))(desc)
+
+        transitions = transitions.replace(desc=desc_normalized, desc_prime=desc_normalized)
+        replay_buffer = replay_buffer.insert(transitions)
+
         # Initial training state
         random_key, subkey = jax.random.split(random_key)
-        emitter_state = QualityPGEmitterState(
+        emitter_state = QualityDCGEmitterState(
             critic_params=critic_params,
-            critic_optimizer_state=critic_optimizer_state,
+            critic_opt_state=critic_opt_state,
             actor_params=actor_params,
-            actor_opt_state=actor_optimizer_state,
+            actor_opt_state=actor_opt_state,
             target_critic_params=target_critic_params,
             target_actor_params=target_actor_params,
+            replay_buffer=replay_buffer,
             random_key=subkey,
             steps=jnp.array(0),
-            replay_buffer=replay_buffer,
         )
 
         return emitter_state, random_key
 
-    @partial(
-        jax.jit,
-        static_argnames=("self",),
-    )
+    @partial(jax.jit, static_argnames=("self",))
+    def _similarity(self, descs_1, descs_2):
+        """Compute the similarity between two batches of descriptors.
+        Args:
+            descs_1: batch of descriptors, representing the observed descriptors of the trajectories.
+            descs_2: batch of descriptors, representing the sampled descriptors.
+        Returns:
+            batch of similarity measures.
+        """
+        return jnp.exp(-jnp.linalg.norm(descs_1 - descs_2, axis=-1)/self._config.lengthscale)
+
+    @partial(jax.jit, static_argnames=("self",))
+    def _normalize_desc(self, desc):
+        return 2*(desc - self._env.behavior_descriptor_limits[0])/(self._env.behavior_descriptor_limits[1] - self._env.behavior_descriptor_limits[0]) - 1
+
+    @partial(jax.jit, static_argnames=("self",))
+    def _unnormalize_desc(self, desc_normalized):
+        return 0.5 * (self._env.behavior_descriptor_limits[1] - self._env.behavior_descriptor_limits[0]) * desc_normalized + \
+            0.5 * (self._env.behavior_descriptor_limits[1] + self._env.behavior_descriptor_limits[0])
+
+    @partial(jax.jit, static_argnames=("self",))
+    def _compute_equivalent_kernel_bias_with_desc(self, actor_dc_params, desc):
+        """
+        Compute the equivalent bias of the first layer of the actor network
+        given a descriptor.
+        """
+        # Extract kernel and bias of the first layer
+        kernel = actor_dc_params["params"]["Dense_0"]["kernel"]
+        bias = actor_dc_params["params"]["Dense_0"]["bias"]
+
+        # Compute the equivalent bias
+        equivalent_kernel = kernel[:-desc.shape[0], :]
+        equivalent_bias = bias + jnp.dot(desc, kernel[-desc.shape[0]:])
+
+        return equivalent_kernel, equivalent_bias
+
+    @partial(jax.jit, static_argnames=("self",))
+    def _compute_equivalent_params_with_desc(self, actor_dc_params, desc):
+        desc_normalized = self._normalize_desc(desc)
+        equivalent_kernel, equivalent_bias = self._compute_equivalent_kernel_bias_with_desc(actor_dc_params, desc_normalized)
+        actor_dc_params["params"]["Dense_0"]["kernel"] = equivalent_kernel
+        actor_dc_params["params"]["Dense_0"]["bias"] = equivalent_bias
+        return actor_dc_params
+
+    @partial(jax.jit, static_argnames=("self",),)
     def emit(
         self,
-        repertoire: MapElitesRepertoire,
-        emitter_state: QualityPGEmitterState,
+        repertoire: Repertoire,
+        emitter_state: QualityDCGEmitterState,
         random_key: RNGKey,
     ) -> Tuple[Genotype, RNGKey]:
         """Do a step of PG emission.
@@ -204,40 +262,23 @@ class QualityPGEmitter(Emitter):
         Returns:
             A batch of offspring, the new emitter state and a new key.
         """
+        # PG emitter
+        parents_pg, descs_pg, random_key = repertoire.sample_with_descs(random_key, self._config.qpg_batch_size)
+        genotypes_pg = self.emit_pg(emitter_state, parents_pg, descs_pg)
 
-        batch_size = self._config.env_batch_size
+        # Actor injection emitter
+        _, descs_ai, random_key = repertoire.sample_with_descs(random_key, self._config.ai_batch_size)
+        descs_ai = descs_ai.reshape(descs_ai.shape[0], self._env.behavior_descriptor_length)
+        genotypes_ai = self.emit_ai(emitter_state, descs_ai)
 
-        # sample parents
-        mutation_pg_batch_size = int(batch_size - 1)
-        parents, random_key = repertoire.sample(random_key, mutation_pg_batch_size)
+        # Concatenate PG and AI genotypes
+        genotypes = jax.tree_util.tree_map(lambda x1, x2: jnp.concatenate((x1, x2), axis=0), genotypes_pg, genotypes_ai)
 
-        # apply the pg mutation
-        offsprings_pg = self.emit_pg(emitter_state, parents)
+        return genotypes, {"desc_prime": jnp.concatenate([descs_pg, descs_ai], axis=0)}, random_key
 
-        # get the actor (greedy actor)
-        offspring_actor = self.emit_actor(emitter_state)
-
-        # add dimension for concatenation
-        offspring_actor = jax.tree_util.tree_map(
-            lambda x: jnp.expand_dims(x, axis=0), offspring_actor
-        )
-
-        # gather offspring
-        genotypes = jax.tree_util.tree_map(
-            lambda x, y: jnp.concatenate([x, y], axis=0),
-            offsprings_pg,
-            offspring_actor,
-        )
-
-        return genotypes, {}, random_key
-
-    @partial(
-        jax.jit,
-        static_argnames=("self",),
-    )
+    @partial(jax.jit, static_argnames=("self",),)
     def emit_pg(
-        self, emitter_state: QualityPGEmitterState, parents: Genotype
-    ) -> Genotype:
+        self, emitter_state: QualityDCGEmitterState, parents: Genotype, descs: Descriptor) -> Genotype:
         """Emit the offsprings generated through pg mutation.
 
         Args:
@@ -245,6 +286,7 @@ class QualityPGEmitter(Emitter):
                 replay buffer.
             parents: the parents selected to be applied gradients in order
                 to mutate towards better performance.
+            descs: the descriptors of the parents.
 
         Returns:
             A new set of offsprings.
@@ -253,15 +295,32 @@ class QualityPGEmitter(Emitter):
             self._mutation_function_pg,
             emitter_state=emitter_state,
         )
-        offsprings = jax.vmap(mutation_fn)(parents)
+        offsprings = jax.vmap(mutation_fn)(parents, descs)
 
         return offsprings
 
-    @partial(
-        jax.jit,
-        static_argnames=("self",),
-    )
-    def emit_actor(self, emitter_state: QualityPGEmitterState) -> Genotype:
+    @partial(jax.jit, static_argnames=("self",),)
+    def emit_ai(
+        self, emitter_state: QualityDCGEmitterState, descs: Descriptor
+    ) -> Genotype:
+        """Emit the offsprings generated through pg mutation.
+
+        Args:
+            emitter_state: current emitter state, contains critic and
+                replay buffer.
+            parents: the parents selected to be applied gradients in order
+                to mutate towards better performance.
+            descs: the descriptors of the parents.
+
+        Returns:
+            A new set of offsprings.
+        """
+        offsprings = jax.vmap(self._compute_equivalent_params_with_desc, in_axes=(None, 0))(emitter_state.actor_params, descs)
+
+        return offsprings
+
+    @partial(jax.jit, static_argnames=("self",))
+    def emit_actor(self, emitter_state: QualityDCGEmitterState) -> Genotype:
         """Emit the greedy actor.
 
         Simply needs to be retrieved from the emitter state.
@@ -275,16 +334,16 @@ class QualityPGEmitter(Emitter):
         """
         return emitter_state.actor_params
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(jax.jit, static_argnames=("self",),)
     def state_update(
         self,
-        emitter_state: QualityPGEmitterState,
-        repertoire: Optional[MapElitesRepertoire],
-        genotypes: Optional[Genotype],
-        fitnesses: Optional[Fitness],
-        descriptors: Optional[Descriptor],
+        emitter_state: QualityDCGEmitterState,
+        repertoire: Repertoire,
+        genotypes: Genotype,
+        fitnesses: Fitness,
+        descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> QualityPGEmitterState:
+    ) -> QualityDCGEmitterState:
         """This function gives an opportunity to update the emitter state
         after the genotypes have been scored.
 
@@ -306,35 +365,50 @@ class QualityPGEmitter(Emitter):
             New emitter state where the replay buffer has been filled with
             the new experienced transitions.
         """
-        # get the transitions out of the dictionary
         assert "transitions" in extra_scores.keys(), "Missing transitions or wrong key"
         transitions = extra_scores["transitions"]
+        episode_length = transitions.obs.shape[1]
 
-        # add transitions in the replay buffer
+        desc_prime = jnp.concatenate([extra_scores["desc_prime"], descriptors[self._config.qpg_batch_size+self._config.ai_batch_size:]], axis=0)
+        desc_prime = jnp.repeat(desc_prime[:, jnp.newaxis, :], episode_length, axis=1)
+        desc = jnp.repeat(descriptors[:, jnp.newaxis, :], episode_length, axis=1)
+
+        desc_prime_normalized = jax.vmap(jax.vmap(self._normalize_desc))(desc_prime)
+        desc_normalized = jax.vmap(jax.vmap(self._normalize_desc))(desc)
+        transitions = transitions.replace(desc=desc_normalized, desc_prime=desc_prime_normalized)
+
+        # Add transitions to replay buffer
         replay_buffer = emitter_state.replay_buffer.insert(transitions)
         emitter_state = emitter_state.replace(replay_buffer=replay_buffer)
 
+        # sample transitions from the replay buffer
+        random_key, subkey = jax.random.split(emitter_state.random_key)
+        transitions, random_key = replay_buffer.sample(subkey, self._config.num_critic_training_steps*self._config.batch_size)
+        transitions = jax.tree_util.tree_map(lambda x: jnp.reshape(x, (self._config.num_critic_training_steps, self._config.batch_size, *x.shape[1:])), transitions)
+        transitions = transitions.replace(rewards=self._similarity(transitions.desc, transitions.desc_prime)*transitions.rewards)
+        emitter_state = emitter_state.replace(random_key=random_key)
+
         def scan_train_critics(
-            carry: QualityPGEmitterState, unused: Any
-        ) -> Tuple[QualityPGEmitterState, Any]:
+            carry: QualityDCGEmitterState, transitions
+        ) -> Tuple[QualityDCGEmitterState, Any]:
             emitter_state = carry
-            new_emitter_state = self._train_critics(emitter_state)
+            new_emitter_state = self._train_critics(emitter_state, transitions)
             return new_emitter_state, ()
 
         # Train critics and greedy actor
         emitter_state, _ = jax.lax.scan(
             scan_train_critics,
             emitter_state,
-            (),
+            transitions,
             length=self._config.num_critic_training_steps,
         )
 
-        return emitter_state  # type: ignore
+        return emitter_state
 
     @partial(jax.jit, static_argnames=("self",))
     def _train_critics(
-        self, emitter_state: QualityPGEmitterState
-    ) -> QualityPGEmitterState:
+        self, emitter_state: QualityDCGEmitterState, transitions
+    ) -> QualityDCGEmitterState:
         """Apply one gradient step to critics and to the greedy actor
         (contained in carry in training_state), then soft update target critics
         and target actor.
@@ -348,17 +422,9 @@ class QualityPGEmitter(Emitter):
             New emitter state where the critic and the greedy actor have been
             updated. Optimizer states have also been updated in the process.
         """
-
-        # Sample a batch of transitions in the buffer
-        random_key = emitter_state.random_key
-        replay_buffer = emitter_state.replay_buffer
-        transitions, random_key = replay_buffer.sample(
-            random_key, sample_size=self._config.batch_size
-        )
-
         # Update Critic
         (
-            critic_optimizer_state,
+            critic_opt_state,
             critic_params,
             target_critic_params,
             random_key,
@@ -366,13 +432,13 @@ class QualityPGEmitter(Emitter):
             critic_params=emitter_state.critic_params,
             target_critic_params=emitter_state.target_critic_params,
             target_actor_params=emitter_state.target_actor_params,
-            critic_optimizer_state=emitter_state.critic_optimizer_state,
+            critic_opt_state=emitter_state.critic_opt_state,
             transitions=transitions,
-            random_key=random_key,
+            random_key=emitter_state.random_key,
         )
 
         # Update greedy actor
-        (actor_optimizer_state, actor_params, target_actor_params,) = jax.lax.cond(
+        (actor_opt_state, actor_params, target_actor_params,) = jax.lax.cond(
             emitter_state.steps % self._config.policy_delay == 0,
             lambda x: self._update_actor(*x),
             lambda _: (
@@ -392,14 +458,13 @@ class QualityPGEmitter(Emitter):
         # Create new training state
         new_emitter_state = emitter_state.replace(
             critic_params=critic_params,
-            critic_optimizer_state=critic_optimizer_state,
+            critic_opt_state=critic_opt_state,
             actor_params=actor_params,
-            actor_opt_state=actor_optimizer_state,
+            actor_opt_state=actor_opt_state,
             target_critic_params=target_critic_params,
             target_actor_params=target_actor_params,
             random_key=random_key,
             steps=emitter_state.steps + 1,
-            replay_buffer=replay_buffer,
         )
 
         return new_emitter_state  # type: ignore
@@ -410,8 +475,8 @@ class QualityPGEmitter(Emitter):
         critic_params: Params,
         target_critic_params: Params,
         target_actor_params: Params,
-        critic_optimizer_state: Params,
-        transitions: QDTransition,
+        critic_opt_state: Params,
+        transitions: DCGTransition,
         random_key: RNGKey,
     ) -> Tuple[Params, Params, Params, RNGKey]:
 
@@ -424,8 +489,8 @@ class QualityPGEmitter(Emitter):
             transitions,
             subkey,
         )
-        critic_updates, critic_optimizer_state = self._critic_optimizer.update(
-            critic_gradient, critic_optimizer_state
+        critic_updates, critic_opt_state = self._critic_optimizer.update(
+            critic_gradient, critic_opt_state
         )
 
         # update critic
@@ -439,7 +504,7 @@ class QualityPGEmitter(Emitter):
             critic_params,
         )
 
-        return critic_optimizer_state, critic_params, target_critic_params, random_key
+        return critic_opt_state, critic_params, target_critic_params, random_key
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_actor(
@@ -448,18 +513,18 @@ class QualityPGEmitter(Emitter):
         actor_opt_state: optax.OptState,
         target_actor_params: Params,
         critic_params: Params,
-        transitions: QDTransition,
+        transitions: DCGTransition,
     ) -> Tuple[optax.OptState, Params, Params]:
 
         # Update greedy actor
-        policy_loss, policy_gradient = jax.value_and_grad(self._policy_loss_fn)(
+        policy_loss, policy_gradient = jax.value_and_grad(self._actor_loss_fn)(
             actor_params,
             critic_params,
             transitions,
         )
         (
             policy_updates,
-            actor_optimizer_state,
+            actor_opt_state,
         ) = self._actor_optimizer.update(policy_gradient, actor_opt_state)
         actor_params = optax.apply_updates(actor_params, policy_updates)
 
@@ -472,16 +537,17 @@ class QualityPGEmitter(Emitter):
         )
 
         return (
-            actor_optimizer_state,
+            actor_opt_state,
             actor_params,
             target_actor_params,
         )
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(jax.jit, static_argnames=("self",),)
     def _mutation_function_pg(
         self,
         policy_params: Genotype,
-        emitter_state: QualityPGEmitterState,
+        descs: Descriptor,
+        emitter_state: QualityDCGEmitterState,
     ) -> Genotype:
         """Apply pg mutation to a policy via multiple steps of gradient descent.
         First, update the rewards to be diversity rewards, then apply the gradient
@@ -496,34 +562,44 @@ class QualityPGEmitter(Emitter):
         Returns:
             The updated params of the neural network.
         """
+        # Get transitions
+        transitions, random_key = emitter_state.replay_buffer.sample(emitter_state.random_key, sample_size=self._config.num_pg_training_steps*self._config.batch_size)
+        descs_prime = jnp.tile(descs, (self._config.num_pg_training_steps*self._config.batch_size, 1))
+        descs_prime_normalized = jax.vmap(self._normalize_desc)(descs_prime)
+        transitions = transitions.replace(rewards=self._similarity(transitions.desc, descs_prime_normalized)*transitions.rewards, desc_prime=descs_prime_normalized)
+        transitions = jax.tree_util.tree_map(lambda x: jnp.reshape(x, (self._config.num_pg_training_steps, self._config.batch_size, *x.shape[1:])), transitions)
+
+        # Replace random_key
+        emitter_state = emitter_state.replace(random_key=random_key)
 
         # Define new policy optimizer state
-        policy_optimizer_state = self._policies_optimizer.init(policy_params)
+        policy_opt_state = self._policies_optimizer.init(policy_params)
 
         def scan_train_policy(
-            carry: Tuple[QualityPGEmitterState, Genotype, optax.OptState],
-            unused: Any,
-        ) -> Tuple[Tuple[QualityPGEmitterState, Genotype, optax.OptState], Any]:
-            emitter_state, policy_params, policy_optimizer_state = carry
+            carry: Tuple[QualityDCGEmitterState, Genotype, optax.OptState],
+            transitions,
+        ) -> Tuple[Tuple[QualityDCGEmitterState, Genotype, optax.OptState], Any]:
+            emitter_state, policy_params, policy_opt_state = carry
             (
                 new_emitter_state,
                 new_policy_params,
-                new_policy_optimizer_state,
+                new_policy_opt_state,
             ) = self._train_policy(
                 emitter_state,
                 policy_params,
-                policy_optimizer_state,
+                policy_opt_state,
+                transitions,
             )
             return (
                 new_emitter_state,
                 new_policy_params,
-                new_policy_optimizer_state,
+                new_policy_opt_state,
             ), ()
 
-        (emitter_state, policy_params, policy_optimizer_state,), _ = jax.lax.scan(
+        (emitter_state, policy_params, policy_opt_state,), _ = jax.lax.scan(
             scan_train_policy,
-            (emitter_state, policy_params, policy_optimizer_state),
-            (),
+            (emitter_state, policy_params, policy_opt_state),
+            transitions,
             length=self._config.num_pg_training_steps,
         )
 
@@ -532,10 +608,11 @@ class QualityPGEmitter(Emitter):
     @partial(jax.jit, static_argnames=("self",))
     def _train_policy(
         self,
-        emitter_state: QualityPGEmitterState,
+        emitter_state: QualityDCGEmitterState,
         policy_params: Params,
-        policy_optimizer_state: optax.OptState,
-    ) -> Tuple[QualityPGEmitterState, Params, optax.OptState]:
+        policy_opt_state: optax.OptState,
+        transitions,
+    ) -> Tuple[QualityDCGEmitterState, Params, optax.OptState]:
         """Apply one gradient step to a policy (called policy_params).
 
         Args:
@@ -546,37 +623,23 @@ class QualityPGEmitter(Emitter):
         Returns:
             The new emitter state and new params of the NN.
         """
-
-        # Sample a batch of transitions in the buffer
-        random_key = emitter_state.random_key
-        replay_buffer = emitter_state.replay_buffer
-        transitions, random_key = replay_buffer.sample(
-            random_key, sample_size=self._config.batch_size
-        )
-
         # update policy
-        policy_optimizer_state, policy_params = self._update_policy(
+        policy_opt_state, policy_params = self._update_policy(
             critic_params=emitter_state.critic_params,
-            policy_optimizer_state=policy_optimizer_state,
+            policy_opt_state=policy_opt_state,
             policy_params=policy_params,
             transitions=transitions,
         )
 
-        # Create new training state
-        new_emitter_state = emitter_state.replace(
-            random_key=random_key,
-            replay_buffer=replay_buffer,
-        )
-
-        return new_emitter_state, policy_params, policy_optimizer_state
+        return emitter_state, policy_params, policy_opt_state
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(
         self,
         critic_params: Params,
-        policy_optimizer_state: optax.OptState,
+        policy_opt_state: optax.OptState,
         policy_params: Params,
-        transitions: QDTransition,
+        transitions: DCGTransition,
     ) -> Tuple[optax.OptState, Params]:
 
         # compute loss
@@ -588,8 +651,8 @@ class QualityPGEmitter(Emitter):
         # Compute gradient and update policies
         (
             policy_updates,
-            policy_optimizer_state,
-        ) = self._policies_optimizer.update(policy_gradient, policy_optimizer_state)
+            policy_opt_state,
+        ) = self._policies_optimizer.update(policy_gradient, policy_opt_state)
         policy_params = optax.apply_updates(policy_params, policy_updates)
 
-        return policy_optimizer_state, policy_params
+        return policy_opt_state, policy_params

--- a/qdax/core/emitters/standard_emitters.py
+++ b/qdax/core/emitters/standard_emitters.py
@@ -75,7 +75,7 @@ class MixingEmitter(Emitter):
                 x_mutation,
             )
 
-        return genotypes, random_key
+        return genotypes, {}, random_key
 
     @property
     def batch_size(self) -> int:

--- a/qdax/core/map_elites.py
+++ b/qdax/core/map_elites.py
@@ -23,7 +23,7 @@ class MAPElites:
     """Core elements of the MAP-Elites algorithm.
 
     Note: Although very similar to the GeneticAlgorithm, we decided to keep the
-    MAPElites class independent of the GeneticAlgorithm class at the moment to keep
+    MAPElites class independant of the GeneticAlgorithm class at the moment to keep
     elements explicit.
 
     Args:
@@ -52,7 +52,7 @@ class MAPElites:
     @partial(jax.jit, static_argnames=("self",))
     def init(
         self,
-        init_genotypes: Genotype,
+        genotypes: Genotype,
         centroids: Centroid,
         random_key: RNGKey,
     ) -> Tuple[MapElitesRepertoire, Optional[EmitterState], RNGKey]:
@@ -62,9 +62,9 @@ class MAPElites:
         such as CVT or Euclidean mapping.
 
         Args:
-            init_genotypes: initial genotypes, pytree in which leaves
+            genotypes: initial genotypes, pytree in which leaves
                 have shape (batch_size, num_features)
-            centroids: tessellation centroids of shape (batch_size, num_descriptors)
+            centroids: tesselation centroids of shape (batch_size, num_descriptors)
             random_key: a random key used for stochastic operations.
 
         Returns:
@@ -73,12 +73,12 @@ class MAPElites:
         """
         # score initial genotypes
         fitnesses, descriptors, extra_scores, random_key = self._scoring_function(
-            init_genotypes, random_key
+            genotypes, random_key
         )
 
         # init the repertoire
         repertoire = MapElitesRepertoire.init(
-            genotypes=init_genotypes,
+            genotypes=genotypes,
             fitnesses=fitnesses,
             descriptors=descriptors,
             centroids=centroids,
@@ -87,14 +87,9 @@ class MAPElites:
 
         # get initial state of the emitter
         emitter_state, random_key = self._emitter.init(
-            init_genotypes=init_genotypes, random_key=random_key
-        )
-
-        # update emitter state
-        emitter_state = self._emitter.state_update(
-            emitter_state=emitter_state,
+            random_key,
             repertoire=repertoire,
-            genotypes=init_genotypes,
+            genotypes=genotypes,
             fitnesses=fitnesses,
             descriptors=descriptors,
             extra_scores=extra_scores,
@@ -129,9 +124,10 @@ class MAPElites:
             a new jax PRNG key
         """
         # generate offsprings with the emitter
-        genotypes, random_key = self._emitter.emit(
+        genotypes, extra_info, random_key = self._emitter.emit(
             repertoire, emitter_state, random_key
         )
+
         # scores the offsprings
         fitnesses, descriptors, extra_scores, random_key = self._scoring_function(
             genotypes, random_key
@@ -147,7 +143,7 @@ class MAPElites:
             genotypes=genotypes,
             fitnesses=fitnesses,
             descriptors=descriptors,
-            extra_scores=extra_scores,
+            extra_scores=extra_scores | extra_info,
         )
 
         # update the metrics

--- a/qdax/core/neuroevolution/buffers/buffer.py
+++ b/qdax/core/neuroevolution/buffers/buffer.py
@@ -7,7 +7,7 @@ import flax
 import jax
 import jax.numpy as jnp
 
-from qdax.types import Action, Done, Observation, Reward, RNGKey, StateDescriptor
+from qdax.types import Action, Done, Observation, Reward, RNGKey, StateDescriptor, Descriptor
 
 
 class Transition(flax.struct.PyTreeNode):
@@ -258,6 +258,152 @@ class QDTransition(Transition):
             actions=jnp.zeros(shape=(1, action_dim)),
             state_desc=jnp.zeros(shape=(1, descriptor_dim)),
             next_state_desc=jnp.zeros(shape=(1, descriptor_dim)),
+        )
+        return dummy_transition
+
+
+class DCGTransition(QDTransition):
+    """Stores data corresponding to a transition collected by a QD algorithm."""
+
+    desc: Descriptor
+    desc_prime: Descriptor
+
+    @property
+    def descriptor_dim(self) -> int:
+        """
+        Returns:
+            the dimension of the descriptors.
+        """
+        return self.state_desc.shape[-1]  # type: ignore
+
+    @property
+    def flatten_dim(self) -> int:
+        """
+        Returns:
+            the dimension of the transition once flattened.
+        """
+        flatten_dim = (
+            2 * self.observation_dim
+            + self.action_dim
+            + 3
+            + 2 * self.state_descriptor_dim
+            + 2 * self.descriptor_dim
+        )
+        return flatten_dim
+
+    def flatten(self) -> jnp.ndarray:
+        """
+        Returns:
+            a jnp.ndarray that corresponds to the flattened transition.
+        """
+        flatten_transition = jnp.concatenate(
+            [
+                self.obs,
+                self.next_obs,
+                jnp.expand_dims(self.rewards, axis=-1),
+                jnp.expand_dims(self.dones, axis=-1),
+                jnp.expand_dims(self.truncations, axis=-1),
+                self.actions,
+                self.state_desc,
+                self.next_state_desc,
+                self.desc,
+                self.desc_prime,
+            ],
+            axis=-1,
+        )
+        return flatten_transition
+
+    @classmethod
+    def from_flatten(
+        cls,
+        flattened_transition: jnp.ndarray,
+        transition: QDTransition,
+    ) -> QDTransition:
+        """
+        Creates a transition from a flattened transition in a jnp.ndarray.
+        Args:
+            flattened_transition: flattened transition in a jnp.ndarray of shape
+                (batch_size, flatten_dim)
+            transition: a transition object (might be a dummy one) to
+                get the dimensions right
+        Returns:
+            a Transition object
+        """
+        obs_dim = transition.observation_dim
+        action_dim = transition.action_dim
+        state_desc_dim = transition.state_descriptor_dim
+        desc_dim = transition.descriptor_dim
+
+        obs = flattened_transition[:, :obs_dim]
+        next_obs = flattened_transition[:, obs_dim : (2 * obs_dim)]
+        rewards = jnp.ravel(flattened_transition[:, (2 * obs_dim) : (2 * obs_dim + 1)])
+        dones = jnp.ravel(
+            flattened_transition[:, (2 * obs_dim + 1) : (2 * obs_dim + 2)]
+        )
+        truncations = jnp.ravel(
+            flattened_transition[:, (2 * obs_dim + 2) : (2 * obs_dim + 3)]
+        )
+        actions = flattened_transition[
+            :, (2 * obs_dim + 3) : (2 * obs_dim + 3 + action_dim)
+        ]
+        state_desc = flattened_transition[
+            :,
+            (2 * obs_dim + 3 + action_dim) : (2 * obs_dim + 3 + action_dim + state_desc_dim),
+        ]
+        next_state_desc = flattened_transition[
+            :,
+            (2 * obs_dim + 3 + action_dim + state_desc_dim) : (
+                2 * obs_dim + 3 + action_dim + 2 * state_desc_dim
+            ),
+        ]
+        desc = flattened_transition[
+            :,
+            (2 * obs_dim + 3 + action_dim + 2 * state_desc_dim) : (
+                2 * obs_dim + 3 + action_dim + 2 * state_desc_dim + desc_dim
+            ),
+        ]
+        desc_prime = flattened_transition[
+            :,
+            (2 * obs_dim + 3 + action_dim + 2 * state_desc_dim + desc_dim) : (
+                2 * obs_dim + 3 + action_dim + 2 * state_desc_dim + 2 * desc_dim
+            ),
+        ]
+        return cls(
+            obs=obs,
+            next_obs=next_obs,
+            rewards=rewards,
+            dones=dones,
+            truncations=truncations,
+            actions=actions,
+            state_desc=state_desc,
+            next_state_desc=next_state_desc,
+            desc=desc,
+            desc_prime=desc_prime,
+        )
+
+    @classmethod
+    def init_dummy(  # type: ignore
+        cls, observation_dim: int, action_dim: int, descriptor_dim: int) -> QDTransition:
+        """
+        Initialize a dummy transition that then can be passed to constructors to get
+        all shapes right.
+        Args:
+            observation_dim: observation dimension
+            action_dim: action dimension
+        Returns:
+            a dummy transition
+        """
+        dummy_transition = DCGTransition(
+            obs=jnp.zeros(shape=(1, observation_dim)),
+            next_obs=jnp.zeros(shape=(1, observation_dim)),
+            rewards=jnp.zeros(shape=(1,)),
+            dones=jnp.zeros(shape=(1,)),
+            truncations=jnp.zeros(shape=(1,)),
+            actions=jnp.zeros(shape=(1, action_dim)),
+            state_desc=jnp.zeros(shape=(1, descriptor_dim)),
+            next_state_desc=jnp.zeros(shape=(1, descriptor_dim)),
+            desc=jnp.zeros(shape=(1, descriptor_dim)),
+            desc_prime=jnp.zeros(shape=(1, descriptor_dim)),
         )
         return dummy_transition
 

--- a/qdax/core/neuroevolution/losses/td3_loss.py
+++ b/qdax/core/neuroevolution/losses/td3_loss.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 
 from qdax.core.neuroevolution.buffers.buffer import Transition
-from qdax.types import Action, Observation, Params, RNGKey
+from qdax.types import Action, Observation, Descriptor, Params, RNGKey
 
 
 def make_td3_loss_fn(
@@ -92,6 +92,97 @@ def make_td3_loss_fn(
         return q_loss
 
     return _policy_loss_fn, _critic_loss_fn
+
+
+def make_td3_loss_dc_fn(
+    policy_fn: Callable[[Params, Observation], jnp.ndarray],
+    actor_fn: Callable[[Params, Observation, Descriptor], jnp.ndarray],
+    critic_fn: Callable[[Params, Observation, Action, Descriptor], jnp.ndarray],
+    reward_scaling: float,
+    discount: float,
+    noise_clip: float,
+    policy_noise: float,
+) -> Tuple[
+    Callable[[Params, Params, Transition], jnp.ndarray],
+    Callable[[Params, Params, Params, Transition, RNGKey], jnp.ndarray],
+]:
+    """Creates the loss functions for TD3.
+    Args:
+        policy_fn: forward pass through the neural network defining the policy.
+        actor_fn: forward pass through the neural network defining the
+            descriptor-conditioned policy.
+        critic_fn: forward pass through the neural network defining the
+            descriptor-conditioned critic.
+        reward_scaling: value to multiply the reward given by the environment.
+        discount: discount factor.
+        noise_clip: value that clips the noise to avoid extreme values.
+        policy_noise: noise applied to smooth the bootstrapping.
+    Returns:
+        Return the loss functions used to train the policy and the critic in TD3.
+    """
+
+    @jax.jit
+    def _policy_loss_fn(
+        policy_params: Params,
+        critic_params: Params,
+        transitions: Transition,
+    ) -> jnp.ndarray:
+        """Policy loss function for TD3 agent"""
+        action = policy_fn(policy_params, obs=transitions.obs)
+        q_value = critic_fn(critic_params, obs=transitions.obs, actions=action, desc=transitions.desc_prime)
+        q1_action = jnp.take(q_value, jnp.asarray([0]), axis=-1)
+        policy_loss = -jnp.mean(q1_action)
+        return policy_loss
+
+    @jax.jit
+    def _actor_loss_fn(
+        actor_params: Params,
+        critic_params: Params,
+        transitions: Transition,
+    ) -> jnp.ndarray:
+        """Descriptor-conditioned policy loss function for TD3 agent"""
+        action = actor_fn(actor_params, obs=transitions.obs, desc=transitions.desc_prime)
+        q_value = critic_fn(critic_params, obs=transitions.obs, actions=action, desc=transitions.desc_prime)
+        q1_action = jnp.take(q_value, jnp.asarray([0]), axis=-1)
+        policy_loss = -jnp.mean(q1_action)
+        return policy_loss
+
+    @jax.jit
+    def _critic_loss_fn(
+        critic_params: Params,
+        target_actor_params: Params,
+        target_critic_params: Params,
+        transitions: Transition,
+        random_key: RNGKey,
+    ) -> jnp.ndarray:
+        """Descriptor-conditioned critic loss function for TD3 agent"""
+        noise = (
+            jax.random.normal(random_key, shape=transitions.actions.shape)
+            * policy_noise
+        ).clip(-noise_clip, noise_clip)
+
+        next_action = (
+            actor_fn(target_actor_params, obs=transitions.next_obs, desc=transitions.desc_prime) + noise
+        ).clip(-1.0, 1.0)
+        next_q = critic_fn(target_critic_params, obs=transitions.next_obs, actions=next_action, desc=transitions.desc_prime)
+        next_v = jnp.min(next_q, axis=-1)
+        target_q = jax.lax.stop_gradient(
+            transitions.rewards * reward_scaling
+            + (1.0 - transitions.dones) * discount * next_v
+        )
+        q_old_action = critic_fn(critic_params, obs=transitions.obs, actions=transitions.actions, desc=transitions.desc_prime)
+        q_error = q_old_action - jnp.expand_dims(target_q, -1)
+
+        # Better bootstrapping for truncated episodes.
+        q_error = q_error * jnp.expand_dims(1.0 - transitions.truncations, -1)
+
+        # compute the loss
+        q_losses = jnp.mean(jnp.square(q_error), axis=-2)
+        q_loss = jnp.sum(q_losses, axis=-1)
+
+        return q_loss
+
+    return _policy_loss_fn, _actor_loss_fn, _critic_loss_fn
 
 
 def td3_policy_loss_fn(

--- a/qdax/core/neuroevolution/mdp_utils.py
+++ b/qdax/core/neuroevolution/mdp_utils.py
@@ -9,7 +9,7 @@ from brax.envs import State as EnvState
 from flax.struct import PyTreeNode
 
 from qdax.core.neuroevolution.buffers.buffer import Transition
-from qdax.types import Genotype, Params, RNGKey
+from qdax.types import Genotype, Params, RNGKey, Descriptor
 
 
 class TrainingState(PyTreeNode):
@@ -61,6 +61,54 @@ def generate_unroll(
     (state, _, _), transitions = jax.lax.scan(
         _scan_play_step_fn,
         (init_state, policy_params, random_key),
+        (),
+        length=episode_length,
+    )
+    return state, transitions
+
+
+@partial(jax.jit, static_argnames=("play_step_actor_dc_fn", "episode_length"))
+def generate_unroll_actor_dc(
+    init_state: EnvState,
+    actor_dc_params: Params,
+    desc: Descriptor,
+    random_key: RNGKey,
+    episode_length: int,
+    play_step_actor_dc_fn: Callable[
+        [EnvState, Descriptor, Params, RNGKey],
+        Tuple[
+            EnvState,
+            Descriptor,
+            Params,
+            RNGKey,
+            Transition,
+        ],
+    ],
+) -> Tuple[EnvState, Transition]:
+    """Generates an episode according to the agent's policy and descriptor, returns the final state of
+    the episode and the transitions of the episode.
+
+    Args:
+        init_state: first state of the rollout.
+        policy_dc_params: descriptor-conditioned policy params.
+        desc: descriptor the policy attempts to achieve.
+        random_key: random key for stochasiticity handling.
+        episode_length: length of the rollout.
+        play_step_fn: function describing how a step need to be taken.
+
+    Returns:
+        A new state, the experienced transition.
+    """
+
+    def _scan_play_step_fn(
+        carry: Tuple[EnvState, Params, Descriptor, RNGKey], unused_arg: Any
+    ) -> Tuple[Tuple[EnvState, Params, Descriptor, RNGKey], Transition]:
+        env_state, actor_dc_params, desc, random_key, transitions = play_step_actor_dc_fn(*carry)
+        return (env_state, actor_dc_params, desc, random_key), transitions
+
+    (state, _, _, _), transitions = jax.lax.scan(
+        _scan_play_step_fn,
+        (init_state, actor_dc_params, desc, random_key),
         (),
         length=episode_length,
     )

--- a/qdax/core/neuroevolution/networks/networks.py
+++ b/qdax/core/neuroevolution/networks/networks.py
@@ -8,29 +8,8 @@ import jax.numpy as jnp
 from brax.training import networks
 
 
-class QModule(nn.Module):
-    """Q Module."""
-
-    hidden_layer_sizes: Tuple[int, ...]
-    n_critics: int = 2
-
-    @nn.compact
-    def __call__(self, obs: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        hidden = jnp.concatenate([obs, actions], axis=-1)
-        res = []
-        for _ in range(self.n_critics):
-            q = networks.MLP(
-                layer_sizes=self.hidden_layer_sizes + (1,),
-                activation=nn.relu,
-                kernel_init=jax.nn.initializers.lecun_uniform(),
-            )(hidden)
-            res.append(q)
-        return jnp.concatenate(res, axis=-1)
-
-
 class MLP(nn.Module):
     """MLP module."""
-
     layer_sizes: Tuple[int, ...]
     activation: Callable[[jnp.ndarray], jnp.ndarray] = nn.relu
     kernel_init: Callable[..., Any] = jax.nn.initializers.lecun_uniform()
@@ -39,15 +18,13 @@ class MLP(nn.Module):
     kernel_init_final: Optional[Callable[..., Any]] = None
 
     @nn.compact
-    def __call__(self, data: jnp.ndarray) -> jnp.ndarray:
-        hidden = data
+    def __call__(self, obs: jnp.ndarray) -> jnp.ndarray:
+        hidden = obs
         for i, hidden_size in enumerate(self.layer_sizes):
 
             if i != len(self.layer_sizes) - 1:
                 hidden = nn.Dense(
                     hidden_size,
-                    # name=f"hidden_{i}", with this version of flax, changing the name
-                    # changes the initialization
                     kernel_init=self.kernel_init,
                     use_bias=self.bias,
                 )(hidden)
@@ -61,7 +38,6 @@ class MLP(nn.Module):
 
                 hidden = nn.Dense(
                     hidden_size,
-                    # name=f"hidden_{i}",
                     kernel_init=kernel_init,
                     use_bias=self.bias,
                 )(hidden)
@@ -70,3 +46,81 @@ class MLP(nn.Module):
                     hidden = self.final_activation(hidden)
 
         return hidden
+
+class MLPDC(nn.Module):
+    """Descriptor-conditioned MLP module."""
+    layer_sizes: Tuple[int, ...]
+    activation: Callable[[jnp.ndarray], jnp.ndarray] = nn.relu
+    kernel_init: Callable[..., Any] = jax.nn.initializers.lecun_uniform()
+    final_activation: Optional[Callable[[jnp.ndarray], jnp.ndarray]] = None
+    bias: bool = True
+    kernel_init_final: Optional[Callable[..., Any]] = None
+
+    @nn.compact
+    def __call__(self, obs: jnp.ndarray, desc: jnp.ndarray) -> jnp.ndarray:
+        hidden = jnp.concatenate([obs, desc], axis=-1)
+        for i, hidden_size in enumerate(self.layer_sizes):
+
+            if i != len(self.layer_sizes) - 1:
+                hidden = nn.Dense(
+                    hidden_size,
+                    kernel_init=self.kernel_init,
+                    use_bias=self.bias,
+                )(hidden)
+                hidden = self.activation(hidden)  # type: ignore
+
+            else:
+                if self.kernel_init_final is not None:
+                    kernel_init = self.kernel_init_final
+                else:
+                    kernel_init = self.kernel_init
+
+                hidden = nn.Dense(
+                    hidden_size,
+                    kernel_init=kernel_init,
+                    use_bias=self.bias,
+                )(hidden)
+
+                if self.final_activation is not None:
+                    hidden = self.final_activation(hidden)
+
+        return hidden
+
+
+class QModule(nn.Module):
+    """Q Module."""
+
+    hidden_layer_sizes: Tuple[int, ...]
+    n_critics: int = 2
+
+    @nn.compact
+    def __call__(self, obs: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        hidden = jnp.concatenate([obs, actions], axis=-1)
+        res = []
+        for _ in range(self.n_critics):
+            q = MLP(
+                layer_sizes=self.hidden_layer_sizes + (1,),
+                activation=nn.relu,
+                kernel_init=jax.nn.initializers.lecun_uniform(),
+            )(hidden)
+            res.append(q)
+        return jnp.concatenate(res, axis=-1)
+
+class QModuleDC(nn.Module):
+    """Q Module."""
+
+    hidden_layer_sizes: Tuple[int, ...]
+    n_critics: int = 2
+
+    @nn.compact
+    def __call__(self, obs: jnp.ndarray, actions: jnp.ndarray, desc: jnp.ndarray) -> jnp.ndarray:
+        hidden = jnp.concatenate([obs, actions], axis=-1)
+        res = []
+        for _ in range(self.n_critics):
+            q = MLPDC(
+                layer_sizes=self.hidden_layer_sizes + (1,),
+                activation=nn.relu,
+                kernel_init=jax.nn.initializers.lecun_uniform(),
+            )(hidden, desc)
+            res.append(q)
+        return jnp.concatenate(res, axis=-1)

--- a/qdax/environments/wrappers.py
+++ b/qdax/environments/wrappers.py
@@ -3,7 +3,7 @@ from typing import Dict
 import flax.struct
 import jax
 from brax.v1 import jumpy as jp
-from brax.v1.envs import State, Wrapper
+from brax.v1.envs import State, Wrapper, Env
 
 
 class CompletedEvalMetrics(flax.struct.PyTreeNode):
@@ -69,3 +69,65 @@ class CompletedEvalWrapper(Wrapper):
         )
         nstate.info[self.STATE_INFO_KEY] = eval_metrics
         return nstate
+
+class ClipRewardWrapper(Wrapper):
+    """Wraps gym environments to clip the reward to be greater than 0.
+
+    Utilisation is simple: create an environment with Brax, pass
+    it to the wrapper with the name of the environment, and it will
+    work like before and will simply clip the reward to be greater than 0.
+    """
+
+    def __init__(self, env: Env, clip_min=None, clip_max=None) -> None:
+        super().__init__(env)
+        self._clip_min = clip_min
+        self._clip_max = clip_max
+
+    def reset(self, rng: jp.ndarray) -> State:
+        state = self.env.reset(rng)
+        return state.replace(reward=jp.clip(state.reward, a_min=self._clip_min, a_max=self._clip_max))
+
+    def step(self, state: State, action: jp.ndarray) -> State:
+        state = self.env.step(state, action)
+        return state.replace(reward=jp.clip(state.reward, a_min=self._clip_min, a_max=self._clip_max))
+
+class AffineRewardWrapper(Wrapper):
+    """Wraps gym environments to clip the reward.
+
+    Utilisation is simple: create an environment with Brax, pass
+    it to the wrapper with the name of the environment, and it will
+    work like before and will simply clip the reward to be greater than 0.
+    """
+
+    def __init__(self, env: Env, clip_min=None, clip_max=None) -> None:
+        super().__init__(env)
+        self._clip_min = clip_min
+        self._clip_max = clip_max
+
+    def reset(self, rng: jp.ndarray) -> State:
+        state = self.env.reset(rng)
+        return state.replace(reward=jp.clip(state.reward, a_min=self._clip_min, a_max=self._clip_max))
+
+    def step(self, state: State, action: jp.ndarray) -> State:
+        state = self.env.step(state, action)
+        return state.replace(reward=jp.clip(state.reward, a_min=self._clip_min, a_max=self._clip_max))
+
+class OffsetRewardWrapper(Wrapper):
+    """Wraps gym environments to offset the reward to be greater than 0.
+
+    Utilisation is simple: create an environment with Brax, pass
+    it to the wrapper with the name of the environment, and it will
+    work like before and will simply clip the reward to be greater than 0.
+    """
+
+    def __init__(self, env: Env, offset=0.) -> None:
+        super().__init__(env)
+        self._offset = offset
+
+    def reset(self, rng: jp.ndarray) -> State:
+        state = self.env.reset(rng)
+        return state.replace(reward=state.reward + self._offset)
+
+    def step(self, state: State, action: jp.ndarray) -> State:
+        state = self.env.step(state, action)
+        return state.replace(reward=state.reward + self._offset)


### PR DESCRIPTION
Add DCG-MAP-Elites algorithm to QDax.

This PR introduces:
- a new method for MAP-Elites repertoire, that enables to samples individuals with their corresponding descriptors.
- a new output `extra_info` for `Emitter.emit` methods that is similar to the `extra_scores` of the scoring function, and that enables to pass information from the `emit` step to the `state_update` (necessary for DCG-MAP-Elites).
- a new `DCGTransition` that add `desc` and `desc_prime` to the `QDTransition`.
- descriptor-conditioned TD3 loss, descriptor-conditioned scoring functions, descriptor-conditioned MLP
- two new reward wrappers to clip and offset the reward (necessary for DCG-MAP-Elites).