### PR TITLE
Update the contribution guide in the documentation

### DIFF
--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # Contributing
 
-We'd love to accept your patches and contributions to this project. When contributing to the repository, please make sure to first discuss the changes you wish to make via an issue.
+We'd love to accept your patches and contributions to this project. When contributing to the repository, please make sure to first discuss the changes you wish to make via a [github issue](https://github.com/adaptive-intelligent-robotics/QDax/issues).
 
-Then, there are just a few small guidelines you need to follow.
+After the issue is discussed and the solution is determined, you will be invited to fork the repository and create a branch to implement the solution. Once ready to be merged, you can create a [Pull Request](https://github.com/adaptive-intelligent-robotics/QDax/pulls) on github and request to merge into the branch **develop**.
+
+When implementing your contribution, there are just a few guidelines you need to follow.
 
 ## Installing Pre-commit hooks
 


### PR DESCRIPTION
Related issues: #170 

Adding a few sentences to better explain the contribution process. In particular, made it clear that one needs to start by opening a github issue, then fork the repository (unless having permission to branch inside the main project), and request to merge to develop once the contribution is ready.

## Checks

- [x] a clear description of the PR has been added
- [x] sufficient tests have been written
- [x] relevant section added to the documentation
- [x] example notebook added to the repo
- [x] clean docstrings and comments have been written
- [x] if any issue/observation has been discovered, a new issue has been opened

## Future improvements

n/a
