### PR TITLE
Fix pareto dominance definition

### DIFF
--- a/qdax/utils/pareto_front.py
+++ b/qdax/utils/pareto_front.py
@@ -76,6 +76,7 @@ def compute_masked_pareto_dominance(
 
     return jnp.any(jnp.logical_and(diff_greater_than_zero, diff_geq_than_zero))
 
+
 def compute_masked_pareto_front(
     batch_of_criteria: jnp.ndarray, mask: Mask
 ) -> jnp.ndarray:

--- a/qdax/utils/pareto_front.py
+++ b/qdax/utils/pareto_front.py
@@ -30,7 +30,6 @@ def compute_pareto_dominance(
     return jnp.any(jnp.logical_and(diff_greater_than_zero, diff_geq_than_zero))
 
 
-
 def compute_pareto_front(batch_of_criteria: jnp.ndarray) -> jnp.ndarray:
     """Returns an array of boolean that states for each element if it is
     in the pareto front or not.

--- a/qdax/utils/pareto_front.py
+++ b/qdax/utils/pareto_front.py
@@ -24,10 +24,6 @@ def compute_pareto_dominance(
         Return booleans when the vector is dominated by the batch.
     """
     diff = jnp.subtract(batch_of_criteria, criteria_point)
-    neutral_values = -jnp.ones_like(diff)
-    diff = jax.vmap(lambda x1, x2: jnp.where(mask, x1, x2), in_axes=(1, 1), out_axes=1)(
-        neutral_values, diff
-    )
     diff_greater_than_zero = jnp.any(diff > 0, axis=-1)
     diff_geq_than_zero = jnp.all(diff >= 0, axis=-1)
 
@@ -75,8 +71,10 @@ def compute_masked_pareto_dominance(
     diff = jax.vmap(lambda x1, x2: jnp.where(mask, x1, x2), in_axes=(1, 1), out_axes=1)(
         neutral_values, diff
     )
-    return jnp.any(jnp.all(diff > 0, axis=-1))
+    diff_greater_than_zero = jnp.any(diff > 0, axis=-1)
+    diff_geq_than_zero = jnp.all(diff >= 0, axis=-1)
 
+    return jnp.any(jnp.logical_and(diff_greater_than_zero, diff_geq_than_zero))
 
 def compute_masked_pareto_front(
     batch_of_criteria: jnp.ndarray, mask: Mask

--- a/qdax/utils/pareto_front.py
+++ b/qdax/utils/pareto_front.py
@@ -24,7 +24,15 @@ def compute_pareto_dominance(
         Return booleans when the vector is dominated by the batch.
     """
     diff = jnp.subtract(batch_of_criteria, criteria_point)
-    return jnp.any(jnp.all(diff > 0, axis=-1))
+    neutral_values = -jnp.ones_like(diff)
+    diff = jax.vmap(lambda x1, x2: jnp.where(mask, x1, x2), in_axes=(1, 1), out_axes=1)(
+        neutral_values, diff
+    )
+    diff_greater_than_zero = jnp.any(diff > 0, axis=-1)
+    diff_geq_than_zero = jnp.all(diff >= 0, axis=-1)
+
+    return jnp.any(jnp.logical_and(diff_greater_than_zero, diff_geq_than_zero))
+
 
 
 def compute_pareto_front(batch_of_criteria: jnp.ndarray) -> jnp.ndarray:


### PR DESCRIPTION
This PR:

-  Fixes the definition of Pareto dominance in `pareto_front.py` to account for solutions which have the same fitness values along one axis.