### PR TITLE
Change deprecated jax type

### DIFF
--- a/qdax/types.py
+++ b/qdax/types.py
@@ -45,5 +45,5 @@ class ParetoFront(Generic[T]):
 Mask: TypeAlias = jnp.ndarray
 
 # Others
-RNGKey: TypeAlias = jax.random.Array
+RNGKey: TypeAlias = jax.Array
 Metrics: TypeAlias = Dict[str, jnp.ndarray]

--- a/qdax/types.py
+++ b/qdax/types.py
@@ -45,5 +45,5 @@ class ParetoFront(Generic[T]):
 Mask: TypeAlias = jnp.ndarray
 
 # Others
-RNGKey: TypeAlias = jax.random.KeyArray
+RNGKey: TypeAlias = jax.random.Array
 Metrics: TypeAlias = Dict[str, jnp.ndarray]


### PR DESCRIPTION
Related issues: N/A

Fix a bug in `types.py` script, `jax.random.KeyArray` is deprecated in JAX and should be replaced by `jax.Array`.

## Checks

- [x] a clear description of the PR has been added
- [ ] sufficient tests have been written
- [ ] relevant section added to the documentation
- [ ] example notebook added to the repo
- [ ] clean docstrings and comments have been written
- [ ] if any issue/observation has been discovered, a new issue has been opened

## Future improvements
n/a
