### PR TITLE
fix: Change to new-style-jax-rng-keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ min_bd = 0.0
 max_bd = 1.0
 
 # Init a random key
-random_key = jax.random.PRNGKey(seed)
+random_key = jax.random.key(seed)
 
 # Init population of controllers
 random_key, subkey = jax.random.split(random_key)

--- a/examples/aurora.ipynb
+++ b/examples/aurora.ipynb
@@ -159,7 +159,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/cmaes.ipynb
+++ b/examples/cmaes.ipynb
@@ -189,7 +189,7 @@
    "outputs": [],
    "source": [
     "state = cmaes.init()\n",
-    "random_key = jax.random.PRNGKey(0)"
+    "random_key = jax.random.key(0)"
    ]
   },
   {

--- a/examples/cmame.ipynb
+++ b/examples/cmame.ipynb
@@ -217,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "# in CMA-ME settings (from the paper), there is no init population\n",
     "# we multipy by zero to reproduce this setting\n",
     "initial_population = jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.\n",

--- a/examples/cmamega.ipynb
+++ b/examples/cmamega.ipynb
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.key(0)\n",
     "# no initial population - give all the same value as emitter init value\n",
     "initial_population = jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.\n",
     "\n",

--- a/examples/dads.ipynb
+++ b/examples/dads.ipynb
@@ -182,7 +182,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -518,7 +518,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/diayn.ipynb
+++ b/examples/diayn.ipynb
@@ -180,7 +180,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -508,7 +508,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/distributed_mapelites.ipynb
+++ b/examples/distributed_mapelites.ipynb
@@ -185,7 +185,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/jumanji_snake.ipynb
+++ b/examples/jumanji_snake.ipynb
@@ -122,7 +122,7 @@
     "env = jumanji.make('Snake-v1')\n",
     "\n",
     "# Reset your (jit-able) environment\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key = jax.random.key(0)\n",
     "state, timestep = jax.jit(env.reset)(key)\n",
     "\n",
     "# Interact with the (jit-able) environment\n",
@@ -146,7 +146,7 @@
    "outputs": [],
    "source": [
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# get number of actions\n",
     "num_actions = env.action_spec().maximum + 1\n",

--- a/examples/mapelites.ipynb
+++ b/examples/mapelites.ipynb
@@ -146,7 +146,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.Key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",
@@ -507,7 +507,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=rng)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/me_sac_pbt.ipynb
+++ b/examples/me_sac_pbt.ipynb
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, subkey = jax.random.split(key)\n",
     "env_states = jax.jit(env.reset)(rng=subkey)\n",
     "eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)"
@@ -521,7 +521,7 @@
     "%%time\n",
     "rollout = []\n",
     "\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "env_state = jax.jit(env.reset)(rng=rng)\n",
     "\n",
     "training_state, env_state = jax.tree_map(\n",

--- a/examples/me_td3_pbt.ipynb
+++ b/examples/me_td3_pbt.ipynb
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, subkey = jax.random.split(key)\n",
     "env_states = jax.jit(env.reset)(rng=subkey)\n",
     "eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)"

--- a/examples/mees.ipynb
+++ b/examples/mees.ipynb
@@ -163,7 +163,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/mels.ipynb
+++ b/examples/mels.ipynb
@@ -153,7 +153,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",
@@ -522,7 +522,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=rng)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/mome.ipynb
+++ b/examples/mome.ipynb
@@ -216,7 +216,7 @@
    "outputs": [],
    "source": [
     "# initial population\n",
-    "random_key = jax.random.PRNGKey(42)\n",
+    "random_key = jax.random.key(42)\n",
     "random_key, subkey = jax.random.split(random_key)\n",
     "init_genotypes = jax.random.uniform(\n",
     "    random_key, (batch_size, num_variables), minval=minval, maxval=maxval, dtype=jnp.float32\n",

--- a/examples/nsga2_spea2.ipynb
+++ b/examples/nsga2_spea2.ipynb
@@ -193,7 +193,7 @@
    "outputs": [],
    "source": [
     "# Initial population\n",
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "random_key, subkey = jax.random.split(random_key)\n",
     "init_genotypes = jax.random.uniform(\n",
     "    subkey, (batch_size, genotype_dim), minval=minval, maxval=maxval, dtype=jnp.float32\n",

--- a/examples/omgmega.ipynb
+++ b/examples/omgmega.ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "\n",
     "# defines the population\n",
     "random_key, subkey = jax.random.split(random_key)\n",

--- a/examples/pga_aurora.ipynb
+++ b/examples/pga_aurora.ipynb
@@ -177,7 +177,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/pgame.ipynb
+++ b/examples/pgame.ipynb
@@ -156,7 +156,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/qdpg.ipynb
+++ b/examples/qdpg.ipynb
@@ -169,7 +169,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/sac_pbt.ipynb
+++ b/examples/sac_pbt.ipynb
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "# %%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, *keys = jax.random.split(key, num=1 + num_devices)\n",
     "keys = jnp.stack(keys)\n",
     "env_states, eval_env_first_states = jax.pmap(\n",
@@ -534,7 +534,7 @@
     "%%time\n",
     "rollout = []\n",
     "\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "env_state = jax.jit(env.reset)(rng=rng)\n",
     "\n",
     "training_state, env_state = jax.tree_map(\n",

--- a/examples/scripts/me_example.py
+++ b/examples/scripts/me_example.py
@@ -26,7 +26,7 @@ def run_me() -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/examples/smerl.ipynb
+++ b/examples/smerl.ipynb
@@ -187,7 +187,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.Key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -523,7 +523,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/td3_pbt.ipynb
+++ b/examples/td3_pbt.ipynb
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, *keys = jax.random.split(key, num=1 + num_devices)\n",
     "keys = jnp.stack(keys)\n",
     "env_states, eval_env_first_states = jax.pmap(\n",

--- a/qdax/core/containers/mapelites_repertoire.py
+++ b/qdax/core/containers/mapelites_repertoire.py
@@ -56,7 +56,7 @@ def compute_cvt_centroids(
         init="k-means++",
         n_clusters=num_centroids,
         n_init=1,
-        random_state=RandomState(subkey),
+        random_state=RandomState(jax.random.key_data(subkey)),
     )
     k_means.fit(x)
     centroids = k_means.cluster_centers_

--- a/qdax/core/neuroevolution/networks/seq2seq_networks.py
+++ b/qdax/core/neuroevolution/networks/seq2seq_networks.py
@@ -17,7 +17,7 @@ import numpy as np
 from flax import linen as nn
 
 Array = Any
-PRNGKey = Any
+PRNGKey = jax.Array
 
 
 class EncoderLSTM(nn.Module):
@@ -53,7 +53,7 @@ class EncoderLSTM(nn.Module):
     def initialize_carry(batch_size: int, hidden_size: int) -> Tuple[Array, Array]:
         # Use a dummy key since the default state init fn is just zeros.
         return nn.LSTMCell(hidden_size, parent=None).initialize_carry(  # type: ignore
-            jax.random.PRNGKey(0), (batch_size, hidden_size)
+            jax.random.key(0), (batch_size, hidden_size)
         )
 
 

--- a/qdax/tasks/README.md
+++ b/qdax/tasks/README.md
@@ -19,7 +19,7 @@ Notes:
 import jax
 from qdax.tasks.arm import arm_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = arm_scoring_function
@@ -56,7 +56,7 @@ desc_size = 2
 import jax
 from qdax.tasks.standard_functions import sphere_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = sphere_scoring_function
@@ -98,7 +98,7 @@ desc_size = 2
 import jax
 from qdax.tasks.hypervolume_functions import square_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = square_scoring_function

--- a/tests/baselines_test/cmame_test.py
+++ b/tests/baselines_test/cmame_test.py
@@ -81,7 +81,7 @@ def test_cma_me(emitter_type: Type[CMAEmitter]) -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
     initial_population = (
         jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.0
     )

--- a/tests/baselines_test/cmamega_test.py
+++ b/tests/baselines_test/cmamega_test.py
@@ -95,7 +95,7 @@ def test_cma_mega() -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
     initial_population = jax.random.uniform(
         random_key, shape=(batch_size, num_dimensions)
     )

--- a/tests/baselines_test/dads_smerl_test.py
+++ b/tests/baselines_test/dads_smerl_test.py
@@ -71,7 +71,7 @@ def test_dads_smerl() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/dads_test.py
+++ b/tests/baselines_test/dads_test.py
@@ -65,7 +65,7 @@ def test_dads() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/diayn_smerl_test.py
+++ b/tests/baselines_test/diayn_smerl_test.py
@@ -69,7 +69,7 @@ def test_diayn_smerl() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/diayn_test.py
+++ b/tests/baselines_test/diayn_test.py
@@ -62,7 +62,7 @@ def test_diayn() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/ga_test.py
+++ b/tests/baselines_test/ga_test.py
@@ -71,7 +71,7 @@ def test_ga(algorithm_class: Type[GeneticAlgorithm]) -> None:
         return fitnesses, {}, random_key
 
     # initial population
-    random_key = jax.random.PRNGKey(42)
+    random_key = jax.random.key(42)
     random_key, subkey = jax.random.split(random_key)
     init_genotypes = jax.random.uniform(
         subkey,

--- a/tests/baselines_test/me_pbt_sac_test.py
+++ b/tests/baselines_test/me_pbt_sac_test.py
@@ -69,7 +69,7 @@ def test_me_pbt_sac() -> None:
     )
     min_bd, max_bd = env.behavior_descriptor_limits
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)
 

--- a/tests/baselines_test/me_pbt_td3_test.py
+++ b/tests/baselines_test/me_pbt_td3_test.py
@@ -69,7 +69,7 @@ def test_me_pbt_td3() -> None:
     )
     min_bd, max_bd = env.behavior_descriptor_limits
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)
 

--- a/tests/baselines_test/mees_test.py
+++ b/tests/baselines_test/mees_test.py
@@ -47,7 +47,7 @@ def test_mees() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/omgmega_test.py
+++ b/tests/baselines_test/omgmega_test.py
@@ -82,7 +82,7 @@ def test_omg_mega() -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     # defines the population
     random_key, subkey = jax.random.split(random_key)

--- a/tests/baselines_test/pbt_sac_test.py
+++ b/tests/baselines_test/pbt_sac_test.py
@@ -76,7 +76,7 @@ def test_pbt_sac() -> None:
 
         return env_states, eval_env_first_states
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, *keys = jax.random.split(key, num=1 + num_devices)
     keys = jnp.stack(keys)
     env_states, eval_env_first_states = jax.pmap(

--- a/tests/baselines_test/pbt_td3_test.py
+++ b/tests/baselines_test/pbt_td3_test.py
@@ -74,7 +74,7 @@ def test_pbt_td3() -> None:
 
         return env_states, eval_env_first_states
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, *keys = jax.random.split(key, num=1 + num_devices)
     keys = jnp.stack(keys)
     env_states, eval_env_first_states = jax.pmap(

--- a/tests/baselines_test/pgame_test.py
+++ b/tests/baselines_test/pgame_test.py
@@ -54,7 +54,7 @@ def test_pgame() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/qdpg_test.py
+++ b/tests/baselines_test/qdpg_test.py
@@ -69,7 +69,7 @@ def test_qdpg() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/sac_test.py
+++ b/tests/baselines_test/sac_test.py
@@ -53,7 +53,7 @@ def test_sac() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/td3_test.py
+++ b/tests/baselines_test/td3_test.py
@@ -49,7 +49,7 @@ def test_td3() -> None:
         auto_reset=True,
         eval_metrics=True,
     )
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)

--- a/tests/core_test/aurora_test.py
+++ b/tests/core_test/aurora_test.py
@@ -75,7 +75,7 @@ def test_aurora(env_name: str, batch_size: int) -> None:
     log_freq = 5
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init environment
     env, policy_network, scoring_fn, random_key = create_default_brax_task_components(

--- a/tests/core_test/cmaes_test.py
+++ b/tests/core_test/cmaes_test.py
@@ -32,7 +32,7 @@ def test_cmaes() -> None:
     )
 
     state = cmaes.init()
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     iteration_count = 0
     for _ in range(num_iterations):

--- a/tests/core_test/emitters_test/multi_emitter_test.py
+++ b/tests/core_test/emitters_test/multi_emitter_test.py
@@ -27,7 +27,7 @@ def test_multi_emitter() -> None:
     max_bd = max_param
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -51,7 +51,7 @@ def test_map_elites(env_name: str, batch_size: int) -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -40,7 +40,7 @@ def test_mels(env_name: str, batch_size: int) -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -79,7 +79,7 @@ def test_mome(num_descriptors: int) -> None:
     metrics_function = partial(default_moqd_metrics, reference_point=reference_point)
 
     # initial population
-    random_key = jax.random.PRNGKey(42)
+    random_key = jax.random.key(42)
     random_key, subkey = jax.random.split(random_key)
     init_genotypes = jax.random.uniform(
         subkey,

--- a/tests/core_test/neuroevolution_test/buffers_test/buffer_test.py
+++ b/tests/core_test/neuroevolution_test/buffers_test/buffer_test.py
@@ -87,7 +87,7 @@ def test_sample() -> None:
     simple_transition = simple_transition.replace(rewards=jnp.arange(3))
 
     replay_buffer = replay_buffer.insert(simple_transition)
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     samples, random_key = replay_buffer.sample(random_key, 3)
 

--- a/tests/default_tasks_test/arm_test.py
+++ b/tests/default_tasks_test/arm_test.py
@@ -41,7 +41,7 @@ def test_arm(task_name: str, batch_size: int) -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)
@@ -110,7 +110,7 @@ def test_arm_scoring_function() -> None:
 
     # Init a random key
     seed = 42
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # arm has xy BD centered at 0.5 0.5 and min max range is [0,1]
     # 0 params of first genotype is horizontal and points towards negative x axis

--- a/tests/default_tasks_test/brax_task_test.py
+++ b/tests/default_tasks_test/brax_task_test.py
@@ -34,7 +34,7 @@ def test_map_elites(env_name: str, batch_size: int, is_task_reset_based: bool) -
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     env, policy_network, scoring_fn, random_key = create_default_brax_task_components(
         env_name=env_name,

--- a/tests/default_tasks_test/hypervolume_functions_test.py
+++ b/tests/default_tasks_test/hypervolume_functions_test.py
@@ -50,7 +50,7 @@ def test_standard_functions(task_name: str, batch_size: int) -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/default_tasks_test/jumanji_envs_test.py
+++ b/tests/default_tasks_test/jumanji_envs_test.py
@@ -30,7 +30,7 @@ def test_jumanji_utils() -> None:
     env = jumanji.make("Snake-v1")
 
     # Reset your (jit-able) environment
-    key = jax.random.PRNGKey(0)
+    key = jax.random.key(0)
     state, _timestep = jax.jit(env.reset)(key)
 
     # Interact with the (jit-able) environment
@@ -38,7 +38,7 @@ def test_jumanji_utils() -> None:
     state, _timestep = jax.jit(env.step)(state, action)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # get number of actions
     num_actions = env.action_spec().maximum + 1

--- a/tests/default_tasks_test/qd_suite_test.py
+++ b/tests/default_tasks_test/qd_suite_test.py
@@ -68,7 +68,7 @@ def test_qd_suite(task_name: str, batch_size: int) -> None:
         grid_shape = tuple([resolution_per_axis for _ in range(bd_size)])
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of parameters
     init_variables = task.get_initial_parameters(init_batch_size)

--- a/tests/default_tasks_test/standard_functions_test.py
+++ b/tests/default_tasks_test/standard_functions_test.py
@@ -40,7 +40,7 @@ def test_standard_functions(task_name: str, batch_size: int) -> None:
     max_bd = max_param
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/environments_test/wrapper_test.py
+++ b/tests/environments_test/wrapper_test.py
@@ -110,7 +110,7 @@ def test_wrapper(env_name: str) -> None:
     print("Observation size: ", env.observation_size)
     print("Action size: ", env.action_size)
 
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
     init_state = env.reset(random_key)
 
     joint_angle = jp.concatenate(

--- a/tests/utils_test/plotting_test.py
+++ b/tests/utils_test/plotting_test.py
@@ -38,7 +38,7 @@ def test_onion_grid(num_descriptors: int, grid_shape: Tuple[int, ...]) -> None:
     minval = jnp.array([0] * num_descriptors)
     maxval = jnp.array([1] * num_descriptors)
 
-    random_key = jax.random.PRNGKey(seed=0)
+    random_key = jax.random.key(seed=0)
     random_key, key_desc, key_fit = jax.random.split(random_key, num=3)
 
     number_samples_test = 300

--- a/tests/utils_test/sampling_test.py
+++ b/tests/utils_test/sampling_test.py
@@ -34,7 +34,7 @@ def test_sampling() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)


### PR DESCRIPTION
All calls to `jax.random.PRNGKey` have been changed to `jax.random.key`. When passing keys to non-jax methods (such as the ones in scikit-learn), we first `jax.key_data` to recover the underlying raw key information before making the call.

Related issues:  https://jax.readthedocs.io/en/latest/jep/9263-typed-keys.html
