### PR TITLE
fix: Change to new-style-jax-rng-keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ min_bd = 0.0
 max_bd = 1.0
 
 # Init a random key
-random_key = jax.random.PRNGKey(seed)
+random_key = jax.random.key(seed)
 
 # Init population of controllers
 random_key, subkey = jax.random.split(random_key)

--- a/examples/aurora.ipynb
+++ b/examples/aurora.ipynb
@@ -146,7 +146,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/cmaes.ipynb
+++ b/examples/cmaes.ipynb
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "state = cmaes.init()\n",
-    "random_key = jax.random.PRNGKey(0)"
+    "random_key = jax.random.key(0)"
    ]
   },
   {

--- a/examples/cmame.ipynb
+++ b/examples/cmame.ipynb
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "# in CMA-ME settings (from the paper), there is no init population\n",
     "# we multipy by zero to reproduce this setting\n",
     "initial_population = jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.\n",

--- a/examples/cmamega.ipynb
+++ b/examples/cmamega.ipynb
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.key(0)\n",
     "# no initial population - give all the same value as emitter init value\n",
     "initial_population = jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.\n",
     "\n",

--- a/examples/dads.ipynb
+++ b/examples/dads.ipynb
@@ -163,7 +163,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -499,7 +499,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/dcrlme.ipynb
+++ b/examples/dcrlme.ipynb
@@ -154,7 +154,7 @@
    "source": [
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init environment\n",
     "env = environments.create(env_name, episode_length=episode_length)\n",

--- a/examples/diayn.ipynb
+++ b/examples/diayn.ipynb
@@ -162,7 +162,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -490,7 +490,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/distributed_mapelites.ipynb
+++ b/examples/distributed_mapelites.ipynb
@@ -176,7 +176,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/jumanji_snake.ipynb
+++ b/examples/jumanji_snake.ipynb
@@ -113,7 +113,7 @@
     "env = jumanji.make('Snake-v1')\n",
     "\n",
     "# Reset your (jit-able) environment\n",
-    "key = jax.random.PRNGKey(0)\n",
+    "key = jax.random.key(0)\n",
     "state, timestep = jax.jit(env.reset)(key)\n",
     "\n",
     "# Interact with the (jit-able) environment\n",
@@ -137,7 +137,7 @@
    "outputs": [],
    "source": [
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# get number of actions\n",
     "num_actions = env.action_spec().maximum + 1\n",

--- a/examples/mapelites.ipynb
+++ b/examples/mapelites.ipynb
@@ -133,7 +133,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.Key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",
@@ -494,7 +494,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=rng)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/me_sac_pbt.ipynb
+++ b/examples/me_sac_pbt.ipynb
@@ -311,6 +311,10 @@
     "    observation_size=env.observation_size,\n",
     "    buffer_size=buffer_size,\n",
     ")\n",
+    "\n",
+    "# Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647\n",
+    "keys = jax.random.key_data(keys)\n",
+    "\n",
     "keys, training_states, _ = jax.pmap(agent_init_fn, axis_name=\"p\", devices=devices)(keys)"
    ]
   },

--- a/examples/me_sac_pbt.ipynb
+++ b/examples/me_sac_pbt.ipynb
@@ -150,7 +150,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, subkey = jax.random.split(key)\n",
     "env_states = jax.jit(env.reset)(rng=subkey)\n",
     "eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)"
@@ -504,7 +504,7 @@
     "%%time\n",
     "rollout = []\n",
     "\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "env_state = jax.jit(env.reset)(rng=rng)\n",
     "\n",
     "training_state, env_state = jax.tree_map(\n",

--- a/examples/me_td3_pbt.ipynb
+++ b/examples/me_td3_pbt.ipynb
@@ -155,7 +155,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, subkey = jax.random.split(key)\n",
     "env_states = jax.jit(env.reset)(rng=subkey)\n",
     "eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)"

--- a/examples/me_td3_pbt.ipynb
+++ b/examples/me_td3_pbt.ipynb
@@ -314,6 +314,10 @@
     "    observation_size=env.observation_size,\n",
     "    buffer_size=buffer_size,\n",
     ")\n",
+    "\n",
+    "# Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647\n",
+    "keys = jax.random.key_data(keys)\n",
+    "\n",
     "keys, training_states, _ = jax.pmap(agent_init_fn, axis_name=\"p\", devices=devices)(keys)"
    ]
   },

--- a/examples/mees.ipynb
+++ b/examples/mees.ipynb
@@ -151,7 +151,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/mels.ipynb
+++ b/examples/mels.ipynb
@@ -140,7 +140,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",
@@ -509,7 +509,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=rng)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/mome.ipynb
+++ b/examples/mome.ipynb
@@ -205,7 +205,7 @@
    "outputs": [],
    "source": [
     "# initial population\n",
-    "random_key = jax.random.PRNGKey(42)\n",
+    "random_key = jax.random.key(42)\n",
     "random_key, subkey = jax.random.split(random_key)\n",
     "genotypes = jax.random.uniform(\n",
     "    random_key, (batch_size, num_variables), minval=minval, maxval=maxval, dtype=jnp.float32\n",

--- a/examples/nsga2_spea2.ipynb
+++ b/examples/nsga2_spea2.ipynb
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "# Initial population\n",
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "random_key, subkey = jax.random.split(random_key)\n",
     "genotypes = jax.random.uniform(\n",
     "    subkey, (batch_size, genotype_dim), minval=minval, maxval=maxval, dtype=jnp.float32\n",

--- a/examples/omgmega.ipynb
+++ b/examples/omgmega.ipynb
@@ -184,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_key = jax.random.PRNGKey(0)\n",
+    "random_key = jax.random.key(0)\n",
     "\n",
     "# defines the population\n",
     "random_key, subkey = jax.random.split(random_key)\n",

--- a/examples/pga_aurora.ipynb
+++ b/examples/pga_aurora.ipynb
@@ -164,7 +164,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/pgame.ipynb
+++ b/examples/pgame.ipynb
@@ -143,7 +143,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/qdpg.ipynb
+++ b/examples/qdpg.ipynb
@@ -157,7 +157,7 @@
     "env = environments.create(env_name, episode_length=episode_length)\n",
     "\n",
     "# Init a random key\n",
-    "random_key = jax.random.PRNGKey(seed)\n",
+    "random_key = jax.random.key(seed)\n",
     "\n",
     "# Init policy network\n",
     "policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)\n",

--- a/examples/sac_pbt.ipynb
+++ b/examples/sac_pbt.ipynb
@@ -269,6 +269,10 @@
     "    observation_size=env.observation_size,\n",
     "    buffer_size=buffer_size,\n",
     ")\n",
+    "\n",
+    "# Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647\n",
+    "keys = jax.random.key_data(keys)\n",
+    "\n",
     "keys, training_states, replay_buffers = jax.pmap(\n",
     "    agent_init_fn, axis_name=\"p\", devices=devices\n",
     ")(keys)"

--- a/examples/sac_pbt.ipynb
+++ b/examples/sac_pbt.ipynb
@@ -210,7 +210,7 @@
    "outputs": [],
    "source": [
     "# %%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, *keys = jax.random.split(key, num=1 + num_devices)\n",
     "keys = jnp.stack(keys)\n",
     "env_states, eval_env_first_states = jax.pmap(\n",
@@ -518,7 +518,7 @@
     "%%time\n",
     "rollout = []\n",
     "\n",
-    "rng = jax.random.PRNGKey(seed=1)\n",
+    "rng = jax.random.key(seed=1)\n",
     "env_state = jax.jit(env.reset)(rng=rng)\n",
     "\n",
     "training_state, env_state = jax.tree_util.tree_map(\n",

--- a/examples/scripts/me_example.py
+++ b/examples/scripts/me_example.py
@@ -26,7 +26,7 @@ def run_me() -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/examples/smerl.ipynb
+++ b/examples/smerl.ipynb
@@ -168,7 +168,7 @@
     "    eval_metrics=True,\n",
     ")\n",
     "\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.Key(seed)\n",
     "env_state = jax.jit(env.reset)(rng=key)\n",
     "eval_env_first_state = jax.jit(eval_env.reset)(rng=key)\n",
     "\n",
@@ -504,7 +504,7 @@
    "outputs": [],
    "source": [
     "rollout = []\n",
-    "random_key = jax.random.PRNGKey(seed=1)\n",
+    "random_key = jax.random.key(seed=1)\n",
     "state = jit_env_reset(rng=random_key)\n",
     "while not state.done:\n",
     "    rollout.append(state)\n",

--- a/examples/td3_pbt.ipynb
+++ b/examples/td3_pbt.ipynb
@@ -232,6 +232,10 @@
     "    observation_size=env.observation_size,\n",
     "    buffer_size=buffer_size,\n",
     ")\n",
+    "\n",
+    "# Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647\n",
+    "keys = jax.random.key_data(keys)\n",
+    "\n",
     "keys, training_states, replay_buffers = jax.pmap(\n",
     "    agent_init_fn, axis_name=\"p\", devices=devices\n",
     ")(keys)"

--- a/examples/td3_pbt.ipynb
+++ b/examples/td3_pbt.ipynb
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "key = jax.random.PRNGKey(seed)\n",
+    "key = jax.random.key(seed)\n",
     "key, *keys = jax.random.split(key, num=1 + num_devices)\n",
     "keys = jnp.stack(keys)\n",
     "env_states, eval_env_first_states = jax.pmap(\n",

--- a/qdax/core/containers/mapelites_repertoire.py
+++ b/qdax/core/containers/mapelites_repertoire.py
@@ -63,7 +63,7 @@ def compute_cvt_centroids(
         init="k-means++",
         n_clusters=num_centroids,
         n_init=1,
-        random_state=RandomState(subkey),
+        random_state=RandomState(jax.random.key_data(subkey)),
     )
     k_means.fit(x)
     centroids = k_means.cluster_centers_

--- a/qdax/core/neuroevolution/networks/seq2seq_networks.py
+++ b/qdax/core/neuroevolution/networks/seq2seq_networks.py
@@ -15,9 +15,6 @@ import jax.numpy as jnp
 import numpy as np
 from flax import linen as nn
 
-Array = Any
-PRNGKey = jax.Array
-
 
 class EncoderLSTM(nn.Module):
     """EncoderLSTM Module wrapped in a lifted scan transform."""
@@ -31,14 +28,16 @@ class EncoderLSTM(nn.Module):
     )
     @nn.compact
     def __call__(
-        self, carry: Tuple[Array, Array], x: Array
-    ) -> Tuple[Tuple[Array, Array], Array]:
+        self, carry: Tuple[jax.Array, jax.Array], x: jax.Array
+    ) -> Tuple[Tuple[jax.Array, jax.Array], jax.Array]:
         """Applies the module."""
         lstm_state, is_eos = carry
         features = lstm_state[0].shape[-1]
         new_lstm_state, y = nn.LSTMCell(features)(lstm_state, x)
 
-        def select_carried_state(new_state: Array, old_state: Array) -> Array:
+        def select_carried_state(
+            new_state: jax.Array, old_state: jax.Array
+        ) -> jax.Array:
             return jnp.where(is_eos[:, np.newaxis], old_state, new_state)
 
         # LSTM state is a tuple (c, h).
@@ -49,7 +48,9 @@ class EncoderLSTM(nn.Module):
         return (carried_lstm_state, is_eos), y
 
     @staticmethod
-    def initialize_carry(batch_size: int, hidden_size: int) -> Tuple[Array, Array]:
+    def initialize_carry(
+        batch_size: int, hidden_size: int
+    ) -> Tuple[jax.Array, jax.Array]:
         # Use a dummy key since the default state init fn is just zeros.
         return nn.LSTMCell(hidden_size, parent=None).initialize_carry(  # type: ignore
             jax.random.key(0), (batch_size, hidden_size)
@@ -62,7 +63,7 @@ class Encoder(nn.Module):
     hidden_size: int
 
     @nn.compact
-    def __call__(self, inputs: Array) -> Array:
+    def __call__(self, inputs: jax.Array) -> jax.Array:
         batch_size = inputs.shape[0]
         lstm = EncoderLSTM(name="encoder_lstm")
         init_lstm_state = lstm.initialize_carry(batch_size, self.hidden_size)
@@ -95,7 +96,7 @@ class DecoderLSTM(nn.Module):
         split_rngs={"params": False, "lstm": True},
     )
     @nn.compact
-    def __call__(self, carry: Tuple[Array, Array], x: Array) -> Array:
+    def __call__(self, carry: Tuple[jax.Array, jax.Array], x: jax.Array) -> jax.Array:
         """Applies the DecoderLSTM model."""
 
         lstm_state, last_prediction = carry
@@ -124,7 +125,9 @@ class Decoder(nn.Module):
     obs_size: int
 
     @nn.compact
-    def __call__(self, inputs: Array, init_state: Any) -> Tuple[Array, Array]:
+    def __call__(
+        self, inputs: jax.Array, init_state: Any
+    ) -> Tuple[jax.Array, jax.Array]:
         """Applies the decoder model.
 
         Args:
@@ -166,8 +169,8 @@ class Seq2seq(nn.Module):
 
     @nn.compact
     def __call__(
-        self, encoder_inputs: Array, decoder_inputs: Array
-    ) -> Tuple[Array, Array]:
+        self, encoder_inputs: jax.Array, decoder_inputs: jax.Array
+    ) -> Tuple[jax.Array, jax.Array]:
         """Applies the seq2seq model.
 
         Args:
@@ -194,7 +197,7 @@ class Seq2seq(nn.Module):
 
         return logits, predictions
 
-    def encode(self, encoder_inputs: Array) -> Array:
+    def encode(self, encoder_inputs: jax.Array) -> jax.Array:
         # encode inputs
         init_decoder_state = self.encoder(encoder_inputs)
         final_output, _hidden_state = init_decoder_state

--- a/qdax/core/neuroevolution/networks/seq2seq_networks.py
+++ b/qdax/core/neuroevolution/networks/seq2seq_networks.py
@@ -16,7 +16,7 @@ import numpy as np
 from flax import linen as nn
 
 Array = Any
-PRNGKey = Any
+PRNGKey = jax.Array
 
 
 class EncoderLSTM(nn.Module):
@@ -52,7 +52,7 @@ class EncoderLSTM(nn.Module):
     def initialize_carry(batch_size: int, hidden_size: int) -> Tuple[Array, Array]:
         # Use a dummy key since the default state init fn is just zeros.
         return nn.LSTMCell(hidden_size, parent=None).initialize_carry(  # type: ignore
-            jax.random.PRNGKey(0), (batch_size, hidden_size)
+            jax.random.key(0), (batch_size, hidden_size)
         )
 
 

--- a/qdax/tasks/README.md
+++ b/qdax/tasks/README.md
@@ -19,7 +19,7 @@ Notes:
 import jax
 from qdax.tasks.arm import arm_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = arm_scoring_function
@@ -56,7 +56,7 @@ desc_size = 2
 import jax
 from qdax.tasks.standard_functions import sphere_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = sphere_scoring_function
@@ -98,7 +98,7 @@ desc_size = 2
 import jax
 from qdax.tasks.hypervolume_functions import square_scoring_function
 
-random_key = jax.random.PRNGKey(0)
+random_key = jax.random.key(0)
 
 # Get scoring function
 scoring_fn = square_scoring_function

--- a/qdax/utils/sampling.py
+++ b/qdax/utils/sampling.py
@@ -159,8 +159,8 @@ def multi_sample_scoring_function(
         # vectorizing over axis 0 vectorizes over the num_samples random keys
         in_axes=(None, 0),
         # indicates that the vectorized axis will become axis 1, i.e., the final
-        # output is shape (batch_size, num_samples, ...)
-        out_axes=1,
+        # output is shape (batch_size, num_samples, ...) except for the random key
+        out_axes=(1, 1, 1, 0),
     )
     all_fitnesses, all_descriptors, all_extra_scores, _ = sample_scoring_fn(
         policies_params, keys

--- a/qdax/utils/train_seq2seq.py
+++ b/qdax/utils/train_seq2seq.py
@@ -19,9 +19,6 @@ from qdax.core.neuroevolution.networks.seq2seq_networks import Seq2seq
 from qdax.custom_types import Params, RNGKey
 from qdax.environments.bd_extractors import AuroraExtraInfoNormalization
 
-Array = Any
-PRNGKey = Any
-
 
 def get_model(
     obs_size: int, teacher_force: bool = False, hidden_size: int = 10
@@ -40,7 +37,7 @@ def get_model(
 
 
 def get_initial_params(
-    model: Seq2seq, random_key: PRNGKey, encoder_input_shape: Tuple[int, ...]
+    model: Seq2seq, random_key: RNGKey, encoder_input_shape: Tuple[int, ...]
 ) -> Dict[str, Any]:
     """
     Returns the initial parameters of a seq2seq model.
@@ -62,8 +59,8 @@ def get_initial_params(
 @jax.jit
 def train_step(
     state: train_state.TrainState,
-    batch: Array,
-    lstm_random_key: PRNGKey,
+    batch: jax.Array,
+    lstm_random_key: RNGKey,
 ) -> Tuple[train_state.TrainState, Dict[str, float]]:
     """
     Trains for one step.

--- a/tests/baselines_test/cmame_test.py
+++ b/tests/baselines_test/cmame_test.py
@@ -81,7 +81,7 @@ def test_cma_me(emitter_type: Type[CMAEmitter]) -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
     initial_population = (
         jax.random.uniform(random_key, shape=(batch_size, num_dimensions)) * 0.0
     )

--- a/tests/baselines_test/cmamega_test.py
+++ b/tests/baselines_test/cmamega_test.py
@@ -95,7 +95,7 @@ def test_cma_mega() -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
     initial_population = jax.random.uniform(
         random_key, shape=(batch_size, num_dimensions)
     )

--- a/tests/baselines_test/dads_smerl_test.py
+++ b/tests/baselines_test/dads_smerl_test.py
@@ -72,7 +72,7 @@ def test_dads_smerl() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/dads_test.py
+++ b/tests/baselines_test/dads_test.py
@@ -66,7 +66,7 @@ def test_dads() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/dcrlme_test.py
+++ b/tests/baselines_test/dcrlme_test.py
@@ -61,7 +61,7 @@ def test_dcrlme() -> None:
     policy_delay = 2
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init environment
     env = environments.create(env_name, episode_length=episode_length)

--- a/tests/baselines_test/diayn_smerl_test.py
+++ b/tests/baselines_test/diayn_smerl_test.py
@@ -69,7 +69,7 @@ def test_diayn_smerl() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/diayn_test.py
+++ b/tests/baselines_test/diayn_test.py
@@ -62,7 +62,7 @@ def test_diayn() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/ga_test.py
+++ b/tests/baselines_test/ga_test.py
@@ -71,7 +71,7 @@ def test_ga(algorithm_class: Type[GeneticAlgorithm]) -> None:
         return fitnesses, {}, random_key
 
     # initial population
-    random_key = jax.random.PRNGKey(42)
+    random_key = jax.random.key(42)
     random_key, subkey = jax.random.split(random_key)
     genotypes = jax.random.uniform(
         subkey,

--- a/tests/baselines_test/me_pbt_sac_test.py
+++ b/tests/baselines_test/me_pbt_sac_test.py
@@ -163,6 +163,9 @@ def test_me_pbt_sac() -> None:
         observation_size=env.observation_size,
         buffer_size=buffer_size,
     )
+
+    # Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647
+    keys = jax.random.key_data(keys)
     keys, training_states, _ = jax.pmap(agent_init_fn, axis_name="p", devices=devices)(
         keys
     )

--- a/tests/baselines_test/me_pbt_sac_test.py
+++ b/tests/baselines_test/me_pbt_sac_test.py
@@ -69,7 +69,7 @@ def test_me_pbt_sac() -> None:
     )
     min_bd, max_bd = env.behavior_descriptor_limits
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)
 

--- a/tests/baselines_test/me_pbt_td3_test.py
+++ b/tests/baselines_test/me_pbt_td3_test.py
@@ -161,6 +161,9 @@ def test_me_pbt_td3() -> None:
         observation_size=env.observation_size,
         buffer_size=buffer_size,
     )
+
+    # Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647
+    keys = jax.random.key_data(keys)
     keys, training_states, _ = jax.pmap(agent_init_fn, axis_name="p", devices=devices)(
         keys
     )

--- a/tests/baselines_test/me_pbt_td3_test.py
+++ b/tests/baselines_test/me_pbt_td3_test.py
@@ -69,7 +69,7 @@ def test_me_pbt_td3() -> None:
     )
     min_bd, max_bd = env.behavior_descriptor_limits
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     eval_env_first_states = jax.jit(eval_env.reset)(rng=subkey)
 

--- a/tests/baselines_test/mees_test.py
+++ b/tests/baselines_test/mees_test.py
@@ -47,7 +47,7 @@ def test_mees() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/omgmega_test.py
+++ b/tests/baselines_test/omgmega_test.py
@@ -82,7 +82,7 @@ def test_omg_mega() -> None:
         max_fitness = jnp.max(adjusted_fitness)
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     # defines the population
     random_key, subkey = jax.random.split(random_key)

--- a/tests/baselines_test/pbt_sac_test.py
+++ b/tests/baselines_test/pbt_sac_test.py
@@ -76,7 +76,7 @@ def test_pbt_sac() -> None:
 
         return env_states, eval_env_first_states
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, *keys = jax.random.split(key, num=1 + num_devices)
     keys = jnp.stack(keys)
     env_states, eval_env_first_states = jax.pmap(

--- a/tests/baselines_test/pbt_sac_test.py
+++ b/tests/baselines_test/pbt_sac_test.py
@@ -104,6 +104,9 @@ def test_pbt_sac() -> None:
         observation_size=env.observation_size,
         buffer_size=buffer_size,
     )
+
+    # Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647
+    keys = jax.random.key_data(keys)
     keys, training_states, replay_buffers = jax.pmap(
         agent_init_fn, axis_name="p", devices=devices
     )(keys)

--- a/tests/baselines_test/pbt_td3_test.py
+++ b/tests/baselines_test/pbt_td3_test.py
@@ -74,7 +74,7 @@ def test_pbt_td3() -> None:
 
         return env_states, eval_env_first_states
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, *keys = jax.random.split(key, num=1 + num_devices)
     keys = jnp.stack(keys)
     env_states, eval_env_first_states = jax.pmap(

--- a/tests/baselines_test/pbt_td3_test.py
+++ b/tests/baselines_test/pbt_td3_test.py
@@ -100,6 +100,9 @@ def test_pbt_td3() -> None:
         observation_size=env.observation_size,
         buffer_size=buffer_size,
     )
+
+    # Need to convert to PRNGKey because of github.com/jax-ml/jax/issues/23647
+    keys = jax.random.key_data(keys)
     keys, training_states, replay_buffers = jax.pmap(
         agent_init_fn, axis_name="p", devices=devices
     )(keys)

--- a/tests/baselines_test/pgame_test.py
+++ b/tests/baselines_test/pgame_test.py
@@ -54,7 +54,7 @@ def test_pgame() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/qdpg_test.py
+++ b/tests/baselines_test/qdpg_test.py
@@ -69,7 +69,7 @@ def test_qdpg() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/baselines_test/sac_test.py
+++ b/tests/baselines_test/sac_test.py
@@ -53,7 +53,7 @@ def test_sac() -> None:
         eval_metrics=True,
     )
 
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)
 

--- a/tests/baselines_test/td3_test.py
+++ b/tests/baselines_test/td3_test.py
@@ -49,7 +49,7 @@ def test_td3() -> None:
         auto_reset=True,
         eval_metrics=True,
     )
-    key = jax.random.PRNGKey(seed)
+    key = jax.random.key(seed)
     key, subkey = jax.random.split(key)
     env_state = jax.jit(env.reset)(rng=key)
     eval_env_first_state = jax.jit(eval_env.reset)(rng=key)

--- a/tests/core_test/aurora_test.py
+++ b/tests/core_test/aurora_test.py
@@ -75,7 +75,7 @@ def test_aurora(env_name: str, batch_size: int) -> None:
     log_freq = 5
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init environment
     env, policy_network, scoring_fn, random_key = create_default_brax_task_components(

--- a/tests/core_test/cmaes_test.py
+++ b/tests/core_test/cmaes_test.py
@@ -32,7 +32,7 @@ def test_cmaes() -> None:
     )
 
     state = cmaes.init()
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     iteration_count = 0
     for _ in range(num_iterations):

--- a/tests/core_test/emitters_test/multi_emitter_test.py
+++ b/tests/core_test/emitters_test/multi_emitter_test.py
@@ -27,7 +27,7 @@ def test_multi_emitter() -> None:
     max_bd = max_param
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -51,7 +51,7 @@ def test_map_elites(env_name: str, batch_size: int) -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -40,7 +40,7 @@ def test_mels(env_name: str, batch_size: int) -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -79,7 +79,7 @@ def test_mome(num_descriptors: int) -> None:
     metrics_function = partial(default_moqd_metrics, reference_point=reference_point)
 
     # initial population
-    random_key = jax.random.PRNGKey(42)
+    random_key = jax.random.key(42)
     random_key, subkey = jax.random.split(random_key)
     genotypes = jax.random.uniform(
         subkey,

--- a/tests/core_test/neuroevolution_test/buffers_test/buffer_test.py
+++ b/tests/core_test/neuroevolution_test/buffers_test/buffer_test.py
@@ -91,7 +91,7 @@ def test_sample() -> None:
     simple_transition = simple_transition.replace(rewards=jnp.arange(3))
 
     replay_buffer = replay_buffer.insert(simple_transition)
-    random_key = jax.random.PRNGKey(0)
+    random_key = jax.random.key(0)
 
     samples, random_key = replay_buffer.sample(random_key, 3)
 

--- a/tests/default_tasks_test/arm_test.py
+++ b/tests/default_tasks_test/arm_test.py
@@ -41,7 +41,7 @@ def test_arm(task_name: str, batch_size: int) -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)
@@ -114,7 +114,7 @@ def test_arm_scoring_function() -> None:
 
     # Init a random key
     seed = 42
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # arm has xy BD centered at 0.5 0.5 and min max range is [0,1]
     # 0 params of first genotype is horizontal and points towards negative x axis

--- a/tests/default_tasks_test/brax_task_test.py
+++ b/tests/default_tasks_test/brax_task_test.py
@@ -34,7 +34,7 @@ def test_map_elites(env_name: str, batch_size: int, is_task_reset_based: bool) -
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     env, policy_network, scoring_fn, random_key = create_default_brax_task_components(
         env_name=env_name,

--- a/tests/default_tasks_test/hypervolume_functions_test.py
+++ b/tests/default_tasks_test/hypervolume_functions_test.py
@@ -50,7 +50,7 @@ def test_standard_functions(task_name: str, batch_size: int) -> None:
     max_bd = 1.0
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/default_tasks_test/jumanji_envs_test.py
+++ b/tests/default_tasks_test/jumanji_envs_test.py
@@ -30,7 +30,7 @@ def test_jumanji_utils() -> None:
     env = jumanji.make("Snake-v1")
 
     # Reset your (jit-able) environment
-    key = jax.random.PRNGKey(0)
+    key = jax.random.key(0)
     state, _timestep = jax.jit(env.reset)(key)
 
     # Interact with the (jit-able) environment
@@ -38,7 +38,7 @@ def test_jumanji_utils() -> None:
     state, _timestep = jax.jit(env.step)(state, action)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # get number of actions
     num_actions = env.action_spec().maximum + 1

--- a/tests/default_tasks_test/qd_suite_test.py
+++ b/tests/default_tasks_test/qd_suite_test.py
@@ -68,7 +68,7 @@ def test_qd_suite(task_name: str, batch_size: int) -> None:
         grid_shape = tuple([resolution_per_axis for _ in range(bd_size)])
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of parameters
     init_variables = task.get_initial_parameters(init_batch_size)

--- a/tests/default_tasks_test/standard_functions_test.py
+++ b/tests/default_tasks_test/standard_functions_test.py
@@ -40,7 +40,7 @@ def test_standard_functions(task_name: str, batch_size: int) -> None:
     max_bd = max_param
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init population of controllers
     random_key, subkey = jax.random.split(random_key)

--- a/tests/environments_test/wrapper_test.py
+++ b/tests/environments_test/wrapper_test.py
@@ -110,7 +110,7 @@ def test_wrapper(env_name: str) -> None:
     print("Observation size: ", env.observation_size)
     print("Action size: ", env.action_size)
 
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
     init_state = env.reset(random_key)
 
     joint_angle = jp.concatenate(

--- a/tests/utils_test/plotting_test.py
+++ b/tests/utils_test/plotting_test.py
@@ -38,7 +38,7 @@ def test_onion_grid(num_descriptors: int, grid_shape: Tuple[int, ...]) -> None:
     minval = jnp.array([0] * num_descriptors)
     maxval = jnp.array([1] * num_descriptors)
 
-    random_key = jax.random.PRNGKey(seed=0)
+    random_key = jax.random.key(seed=0)
     random_key, key_desc, key_fit = jax.random.split(random_key, num=3)
 
     number_samples_test = 300

--- a/tests/utils_test/sampling_test.py
+++ b/tests/utils_test/sampling_test.py
@@ -34,7 +34,7 @@ def test_sampling() -> None:
     env = environments.create(env_name, episode_length=episode_length)
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # Init policy network
     policy_layer_sizes = policy_hidden_layer_sizes + (env.action_size,)

--- a/tests/utils_test/uncertainty_metrics_test.py
+++ b/tests/utils_test/uncertainty_metrics_test.py
@@ -25,7 +25,7 @@ def test_uncertainty_metrics() -> None:
     genotype_dim = 8
 
     # Init a random key
-    random_key = jax.random.PRNGKey(seed)
+    random_key = jax.random.key(seed)
 
     # First, init a deterministic environment
     init_policies = jax.random.uniform(


### PR DESCRIPTION
This PR is an internal copy of #184:

> All calls to jax.random.PRNGKey have been changed to jax.random.key. When passing keys to non-jax methods (such as the ones in scikit-learn), we first jax.key_data to recover the underlying raw key information before making the call.
> Related issues: https://jax.readthedocs.io/en/latest/jep/9263-typed-keys.html

with the following additional changes:
- remaining `jax.random.PRNGKey` have been changed to `jax.random.key`.
- all checks now pass

## Checks

- [x]  a clear description of the PR has been added
