### PR TITLE
Hotfix: remove useless dependencies (including gym dependency)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,9 @@ absl-py==1.0.0
 brax==0.10.4
 chex==0.1.86
 flax==0.8.5
-gym==0.26.2
-ipython
 jax==0.4.28
 jaxlib==0.4.28
 jumanji==0.3.1
-jupyter
 numpy==1.26.4
 optax==0.1.9
 protobuf==3.19.5

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "brax>=0.10.4",
         "chex>=0.1.86",
         "flax>=0.8.5",
-        "gym>=0.26.2",
         "jax>=0.4.28",
         "jaxlib>=0.4.28",  # necessary to build the doc atm
         "jinja2>=3.1.4",


### PR DESCRIPTION
Related issues: #205 

Removing the following useless dependencies from requirements.txt:
- `gym`
- `ipython`
- `jupyter`

## Checks

- [x] a clear description of the PR has been added
N/A sufficient tests have been written
N/A relevant section added to the documentation
N/A example notebook added to the repo
N/A clean docstrings and comments have been written
N/A if any issue/observation has been discovered, a new issue has been opened
