### PR TITLE
Feature vram

### DIFF
--- a/qdax/core/emitters/qpg_emitter.py
+++ b/qdax/core/emitters/qpg_emitter.py
@@ -54,8 +54,7 @@ class QualityPGEmitterState(EmitterState):
     target_critic_params: Params
     target_actor_params: Params
     replay_buffer: ReplayBuffer
-    key: RNGKey
-    steps: jnp.ndarray
+    random_key: RNGKey
 
 
 class QualityPGEmitter(Emitter):
@@ -72,7 +71,9 @@ class QualityPGEmitter(Emitter):
     ) -> None:
         self._config = config
         self._env = env
-        self._policy_network = policy_network
+        self._actor_critic_iterations = int(
+            config.num_critic_training_steps / config.policy_delay
+        )  # actor and critic training are packed into a single function
 
         # Init Critics
         critic_network = QModule(
@@ -120,21 +121,21 @@ class QualityPGEmitter(Emitter):
 
     def init(
         self,
-        key: RNGKey,
+        random_key: RNGKey,
         repertoire: Repertoire,
         genotypes: Genotype,
         fitnesses: Fitness,
         descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> QualityPGEmitterState:
+    ) -> Tuple[QualityPGEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
             genotypes: The initial population.
-            key: A random key.
+            random_key: A random key.
 
         Returns:
-            The initial state of the PGAMEEmitter.
+            The initial state of the PGAMEEmitter, a new random key.
         """
 
         observation_size = self._env.observation_size
@@ -142,16 +143,16 @@ class QualityPGEmitter(Emitter):
         descriptor_size = self._env.state_descriptor_length
 
         # Initialise critic, greedy actor and population
-        key, subkey = jax.random.split(key)
+        random_key, subkey = jax.random.split(random_key)
         fake_obs = jnp.zeros(shape=(observation_size,))
         fake_action = jnp.zeros(shape=(action_size,))
         critic_params = self._critic_network.init(
             subkey, obs=fake_obs, actions=fake_action
         )
-        target_critic_params = jax.tree.map(lambda x: x, critic_params)
+        target_critic_params = jax.tree_util.tree_map(lambda x: x, critic_params)
 
-        actor_params = jax.tree.map(lambda x: x[0], genotypes)
-        target_actor_params = jax.tree.map(lambda x: x[0], genotypes)
+        actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
+        target_actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
 
         # Prepare init optimizer states
         critic_optimizer_state = self._critic_optimizer.init(critic_params)
@@ -176,6 +177,7 @@ class QualityPGEmitter(Emitter):
         replay_buffer = replay_buffer.insert(transitions)
 
         # Initial training state
+        random_key, subkey = jax.random.split(random_key)
         emitter_state = QualityPGEmitterState(
             critic_params=critic_params,
             critic_optimizer_state=critic_optimizer_state,
@@ -184,57 +186,64 @@ class QualityPGEmitter(Emitter):
             target_critic_params=target_critic_params,
             target_actor_params=target_actor_params,
             replay_buffer=replay_buffer,
-            key=key,
-            steps=jnp.array(0),
+            random_key=subkey,
         )
 
-        return emitter_state
+        return emitter_state, random_key
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit(
         self,
         repertoire: Repertoire,
         emitter_state: QualityPGEmitterState,
-        key: RNGKey,
-    ) -> Tuple[Genotype, ExtraScores]:
+        random_key: RNGKey,
+    ) -> Tuple[Genotype, ExtraScores, RNGKey]:
         """Do a step of PG emission.
 
         Args:
             repertoire: the current repertoire of genotypes
             emitter_state: the state of the emitter used
-            key: a random key
+            random_key: a random key
 
         Returns:
-            A batch of offspring, the new emitter state.
+            A batch of offspring, the new emitter state and a new key.
         """
 
         batch_size = self._config.env_batch_size
 
         # sample parents
         mutation_pg_batch_size = int(batch_size - 1)
-        parents = repertoire.sample(key, mutation_pg_batch_size)
+        parents, random_key = repertoire.sample(random_key, mutation_pg_batch_size)
 
         # apply the pg mutation
+        random_key, subkey = jax.random.split(random_key)
+        emitter_state = emitter_state.replace(random_key=subkey)
         offsprings_pg = self.emit_pg(emitter_state, parents)
 
         # get the actor (greedy actor)
         offspring_actor = self.emit_actor(emitter_state)
 
         # add dimension for concatenation
-        offspring_actor = jax.tree.map(
+        offspring_actor = jax.tree_util.tree_map(
             lambda x: jnp.expand_dims(x, axis=0), offspring_actor
         )
 
         # gather offspring
-        genotypes = jax.tree.map(
+        genotypes = jax.tree_util.tree_map(
             lambda x, y: jnp.concatenate([x, y], axis=0),
             offsprings_pg,
             offspring_actor,
         )
 
-        return genotypes, {}
+        return genotypes, {}, random_key
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_pg(
         self, emitter_state: QualityPGEmitterState, parents: Genotype
     ) -> Genotype:
@@ -249,15 +258,50 @@ class QualityPGEmitter(Emitter):
         Returns:
             A new set of offsprings.
         """
-        mutation_fn = partial(
-            self._mutation_function_pg,
-            emitter_state=emitter_state,
+
+        # create a batch of policy optimizer states
+        policy_opt_states = jax.vmap(self._policies_optimizer.init)(parents)
+
+        # prepare the batched policy update function with vmapping
+        batched_policy_update_fn = jax.vmap(
+            partial(self._update_policy, critic_params=emitter_state.critic_params),
+            in_axes=(0, 0, None),
         )
-        offsprings = jax.vmap(mutation_fn)(parents)
 
-        return offsprings
+        def scan_update_policies(
+            carry: Tuple[Params, optax.OptState, RNGKey],
+            _: None,
+        ) -> Tuple[Tuple[Params, optax.OptState, RNGKey], Any]:
 
-    @partial(jax.jit, static_argnames=("self",))
+            # Unpack the carry
+            (policy_params, policy_opt_state, key) = carry
+
+            # sample a mini-batch of data from the replay-buffer
+            transitions, key = emitter_state.replay_buffer.sample(
+                key, self._config.batch_size
+            )
+            (
+                new_policy_params,
+                new_policy_opt_states,
+            ) = batched_policy_update_fn(policy_params, policy_opt_state, transitions)
+            return (new_policy_params, new_policy_opt_states, key), ()
+
+        (
+            final_policy_params,
+            final_policy_opt_state,
+            final_key,
+        ), _ = jax.lax.scan(
+            scan_update_policies,
+            (parents, policy_opt_states, emitter_state.random_key),
+            length=self._config.num_pg_training_steps,
+        )
+
+        return final_policy_params
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_actor(self, emitter_state: QualityPGEmitterState) -> Genotype:
         """Emit the greedy actor.
 
@@ -308,137 +352,79 @@ class QualityPGEmitter(Emitter):
         transitions = extra_scores["transitions"]
 
         # add transitions in the replay buffer
-        replay_buffer = emitter_state.replay_buffer.insert(transitions)
-        emitter_state = emitter_state.replace(replay_buffer=replay_buffer)
-
-        def scan_train_critics(
-            carry: QualityPGEmitterState, _: Any
-        ) -> Tuple[QualityPGEmitterState, Any]:
-            emitter_state = carry
-            new_emitter_state = self._train_critics(emitter_state)
-            return new_emitter_state, ()
-
-        # Train critics and greedy actor
-        emitter_state, _ = jax.lax.scan(
-            scan_train_critics,
-            emitter_state,
-            (),
-            length=self._config.num_critic_training_steps,
+        emitter_state = emitter_state.replace(
+            replay_buffer=emitter_state.replay_buffer.insert(transitions)
         )
 
-        return emitter_state  # type: ignore
+        # Conduct Actor-Critic training
+        final_emitter_state, _ = jax.lax.scan(
+            self._scan_actor_critic_training,
+            emitter_state,
+            length=self._actor_critic_iterations,
+        )
+
+        return final_emitter_state  # type: ignore
 
     @partial(jax.jit, static_argnames=("self",))
-    def _train_critics(
-        self, emitter_state: QualityPGEmitterState
-    ) -> QualityPGEmitterState:
-        """Apply one gradient step to critics and to the greedy actor
-        (contained in carry in training_state), then soft update target critics
-        and target actor.
-
-        Those updates are very similar to those made in TD3.
+    def _scan_update_critic(
+        self,
+        carry: Tuple[Params, Params, optax.OptState, Params, RNGKey],
+        transitions: QDTransition,
+    ) -> Tuple[Tuple[Params, Params, optax.OptState, Params, RNGKey], Any]:
+        """A scan-ready function to update the critic network parameters
+        with one gradient step.
 
         Args:
-            emitter_state: actual emitter state
+            carry: packed carry containing critic parameters, target critic
+                parameters, critic optimiser state, target actor parameters,
+                and the random key.
+            transitions: a mini-batch of QDTransitions for gradient computation
 
         Returns:
-            New emitter state where the critic and the greedy actor have been
-            updated. Optimizer states have also been updated in the process.
+            new_carry: new carry containing updated parameters (target actor
+                parameters is unchanged).
+            empty tuple: compulsory signature for jax.lax.scan
         """
-        key = emitter_state.key
-
-        # Sample a batch of transitions in the buffer
-        key, subkey = jax.random.split(key)
-        replay_buffer = emitter_state.replay_buffer
-        transitions = replay_buffer.sample(subkey, sample_size=self._config.batch_size)
-
-        # Update Critic
-        key, subkey = jax.random.split(key)
+        # unpack the carry
         (
-            critic_optimizer_state,
             critic_params,
             target_critic_params,
-        ) = self._update_critic(
-            critic_params=emitter_state.critic_params,
-            target_critic_params=emitter_state.target_critic_params,
-            target_actor_params=emitter_state.target_actor_params,
-            critic_optimizer_state=emitter_state.critic_optimizer_state,
-            transitions=transitions,
-            key=subkey,
-        )
-
-        # Update greedy actor
-        (
-            actor_optimizer_state,
-            actor_params,
+            critic_opt_state,
             target_actor_params,
-        ) = jax.lax.cond(
-            emitter_state.steps % self._config.policy_delay == 0,
-            lambda x: self._update_actor(*x),
-            lambda _: (
-                emitter_state.actor_opt_state,
-                emitter_state.actor_params,
-                emitter_state.target_actor_params,
-            ),
-            operand=(
-                emitter_state.actor_params,
-                emitter_state.actor_opt_state,
-                emitter_state.target_actor_params,
-                emitter_state.critic_params,
-                transitions,
-            ),
-        )
+            key,
+        ) = carry
 
-        # Create new training state
-        new_emitter_state = emitter_state.replace(
-            critic_params=critic_params,
-            critic_optimizer_state=critic_optimizer_state,
-            actor_params=actor_params,
-            actor_opt_state=actor_optimizer_state,
-            target_critic_params=target_critic_params,
-            target_actor_params=target_actor_params,
-            key=key,
-            steps=emitter_state.steps + 1,
-            replay_buffer=replay_buffer,
-        )
-
-        return new_emitter_state  # type: ignore
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _update_critic(
-        self,
-        critic_params: Params,
-        target_critic_params: Params,
-        target_actor_params: Params,
-        critic_optimizer_state: Params,
-        transitions: QDTransition,
-        key: RNGKey,
-    ) -> Tuple[Params, Params, Params]:
-
-        # compute loss and gradients
+        # compute the critic gradients
+        key, subkey = jax.random.split(key)
         critic_gradient = jax.grad(self._critic_loss_fn)(
             critic_params,
             target_actor_params,
             target_critic_params,
             transitions,
-            key,
+            subkey,
         )
-        critic_updates, critic_optimizer_state = self._critic_optimizer.update(
-            critic_gradient, critic_optimizer_state
-        )
-
         # update critic
-        critic_params = optax.apply_updates(critic_params, critic_updates)
+        critic_updates, new_critic_opt_state = self._critic_optimizer.update(
+            critic_gradient, critic_opt_state
+        )
+        new_critic_params = optax.apply_updates(critic_params, critic_updates)
 
         # Soft update of target critic network
-        target_critic_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_critic_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_critic_params,
-            critic_params,
+            new_critic_params,
         )
-
-        return critic_optimizer_state, critic_params, target_critic_params
+        # pack into new carry
+        new_carry = (
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
+        )
+        return new_carry, ()
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_actor(
@@ -449,6 +435,22 @@ class QualityPGEmitter(Emitter):
         critic_params: Params,
         transitions: QDTransition,
     ) -> Tuple[optax.OptState, Params, Params]:
+        """Function to update the actor with one Policy-Gradient step.
+
+        Args:
+            actor_params: neural network parameters of the actor.
+            actor_opt_state: optimiser state of the actor.
+            target_actor_params: target actor parameters (used in TD3 to
+                smooth the actor-critic learning).
+            critic_params: the parameters of the critic networks which plays
+                as a differentiable target.
+            transitions: a mini-batch of QDTransitions.
+
+        Returns:
+            new_actor_params: new actor parameters after taking the PG step
+            new_target_actor_params: new target actor parameters (soft-tau update)
+            new_actor_opt_state: updated optimiser state
+        """
 
         # Update greedy actor
         policy_gradient = jax.grad(self._policy_loss_fn)(
@@ -458,140 +460,140 @@ class QualityPGEmitter(Emitter):
         )
         (
             policy_updates,
-            actor_optimizer_state,
+            new_actor_opt_state,
         ) = self._actor_optimizer.update(policy_gradient, actor_opt_state)
-        actor_params = optax.apply_updates(actor_params, policy_updates)
+        new_actor_params = optax.apply_updates(actor_params, policy_updates)
 
         # Soft update of target greedy actor
-        target_actor_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_actor_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_actor_params,
-            actor_params,
+            new_actor_params,
         )
 
-        return (
-            actor_optimizer_state,
-            actor_params,
-            target_actor_params,
-        )
+        return new_actor_params, new_target_actor_params, new_actor_opt_state
 
     @partial(jax.jit, static_argnames=("self",))
-    def _mutation_function_pg(
-        self,
-        policy_params: Genotype,
-        emitter_state: QualityPGEmitterState,
-    ) -> Genotype:
-        """Apply pg mutation to a policy via multiple steps of gradient descent.
-        First, update the rewards to be diversity rewards, then apply the gradient
-        steps.
+    def _scan_actor_critic_training(
+        self, carry: QualityPGEmitterState, _: None
+    ) -> Tuple[QualityPGEmitterState, Tuple]:
+        """
+        Perform a few (policy delay) steps of critic followed by one step of
+        actor training, all packed into a single scan-ready function.
+        Transition data are sampled step-by-step to promote memory efficiency.
 
         Args:
-            policy_params: a policy, supposed to be a differentiable neural
-                network.
-            emitter_state: the current state of the emitter, containing among others,
-                the replay buffer, the critic.
+            carry: emitter state
+            _: None
 
         Returns:
-            The updated params of the neural network.
+            new_emitter_state: new emitter state containing updated network
+                parameters as the new carry.
+            empty tuple: compulsory signature for jax.lax.scan
         """
 
-        # Define new policy optimizer state
-        policy_optimizer_state = self._policies_optimizer.init(policy_params)
+        emitter_state = carry
 
-        def scan_train_policy(
-            carry: Tuple[QualityPGEmitterState, Genotype, optax.OptState],
-            _: Any,
-        ) -> Tuple[Tuple[QualityPGEmitterState, Genotype, optax.OptState], Any]:
-            emitter_state, policy_params, policy_optimizer_state = carry
-            (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_optimizer_state,
-            ) = self._train_policy(
-                emitter_state,
-                policy_params,
-                policy_optimizer_state,
-            )
-            return (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_optimizer_state,
-            ), ()
+        # sample transitions
+        transitions, key = emitter_state.replay_buffer.sample(
+            emitter_state.random_key,
+            self._config.batch_size * (self._config.policy_delay + 1),
+        )
+        transitions = jax.tree.map(
+            lambda x: jnp.reshape(
+                x,
+                (
+                    self._config.policy_delay + 1,
+                    self._config.batch_size,
+                    *x.shape[1:],
+                ),
+            ),
+            transitions,
+        )
 
+        # split the transitions for critic and actor
+        critic_data = jax.tree.map(lambda x: x[:-1], transitions)
+        actor_data = jax.tree.map(lambda x: x[-1], transitions)
+
+        # scan training critics
         (
-            emitter_state,
-            policy_params,
-            policy_optimizer_state,
-        ), _ = jax.lax.scan(
-            scan_train_policy,
-            (emitter_state, policy_params, policy_optimizer_state),
-            (),
-            length=self._config.num_pg_training_steps,
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
+        ), () = jax.lax.scan(
+            self._scan_update_critic,
+            (
+                emitter_state.critic_params,
+                emitter_state.target_critic_params,
+                emitter_state.critic_optimizer_state,
+                emitter_state.target_actor_params,
+                key,
+            ),
+            critic_data,
         )
 
-        return policy_params
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _train_policy(
-        self,
-        emitter_state: QualityPGEmitterState,
-        policy_params: Params,
-        policy_optimizer_state: optax.OptState,
-    ) -> Tuple[QualityPGEmitterState, Params, optax.OptState]:
-        """Apply one gradient step to a policy (called policy_params).
-
-        Args:
-            emitter_state: current state of the emitter.
-            policy_params: parameters corresponding to the weights and bias of
-                the neural network that defines the policy.
-
-        Returns:
-            The new emitter state and new params of the NN.
-        """
-        key = emitter_state.key
-
-        # Sample a batch of transitions in the buffer
-        key, subkey = jax.random.split(key)
-        replay_buffer = emitter_state.replay_buffer
-        transitions = replay_buffer.sample(subkey, sample_size=self._config.batch_size)
-
-        # update policy
-        policy_optimizer_state, policy_params = self._update_policy(
-            critic_params=emitter_state.critic_params,
-            policy_optimizer_state=policy_optimizer_state,
-            policy_params=policy_params,
-            transitions=transitions,
+        # update the actor with one gradient step
+        (new_actor_params, new_target_actor_params, new_actor_opt_state) = (
+            self._update_actor(
+                emitter_state.actor_params,
+                emitter_state.actor_opt_state,
+                target_actor_params,
+                new_critic_params,
+                actor_data,
+            )
         )
 
-        # Create new training state
         new_emitter_state = emitter_state.replace(
-            key=key,
-            replay_buffer=replay_buffer,
+            critic_params=new_critic_params,
+            critic_optimizer_state=new_critic_opt_state,
+            actor_params=new_actor_params,
+            actor_opt_state=new_actor_opt_state,
+            target_critic_params=new_target_critic_params,
+            target_actor_params=new_target_actor_params,
+            random_key=key,
         )
 
-        return new_emitter_state, policy_params, policy_optimizer_state
+        return new_emitter_state, ()
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(
         self,
-        critic_params: Params,
-        policy_optimizer_state: optax.OptState,
         policy_params: Params,
+        policy_opt_state: optax.OptState,
         transitions: QDTransition,
+        critic_params: Params,
     ) -> Tuple[optax.OptState, Params]:
+        """
+        Perform one step of PG update on the off-spring policy.
+        This function is vmapped to mutate the entire batch of off-springs
+        in parallel.
 
-        # compute loss
+        Args:
+            policy_params: the parameters of the policy.
+            policy_opt_state: the optimiser state of the policy.
+            transitions: a mini-batch of transitions for gradient computation
+            critic_params: the parameters of the critic networks serving as
+                a differentiable target. This is fixed in each iteration.
+
+        Returns:
+            new_policy_params: new policy parameters
+            new_policy_opt_state: updated optimiser state
+        """
+
+        # Compute the policy gradient
         policy_gradient = jax.grad(self._policy_loss_fn)(
             policy_params,
             critic_params,
             transitions,
         )
-        # Compute gradient and update policies
+        # Apply the update on the policy
         (
             policy_updates,
-            policy_optimizer_state,
-        ) = self._policies_optimizer.update(policy_gradient, policy_optimizer_state)
-        policy_params = optax.apply_updates(policy_params, policy_updates)
+            new_policy_opt_state,
+        ) = self._policies_optimizer.update(policy_gradient, policy_opt_state)
+        new_policy_params = optax.apply_updates(policy_params, policy_updates)
 
-        return policy_optimizer_state, policy_params
+        return new_policy_params, new_policy_opt_state

--- a/qdax/core/neuroevolution/losses/td3_loss.py
+++ b/qdax/core/neuroevolution/losses/td3_loss.py
@@ -56,11 +56,12 @@ def make_td3_loss_fn(
         target_policy_params: Params,
         target_critic_params: Params,
         transitions: Transition,
-        key: RNGKey,
+        random_key: RNGKey,
     ) -> jnp.ndarray:
         """Critics loss function for TD3 agent"""
         noise = (
-            jax.random.normal(key, shape=transitions.actions.shape) * policy_noise
+            jax.random.normal(random_key, shape=transitions.actions.shape)
+            * policy_noise
         ).clip(-noise_clip, noise_clip)
 
         next_action = (
@@ -125,13 +126,12 @@ def make_td3_loss_dc_fn(
     def _policy_loss_fn(
         policy_params: Params,
         critic_params: Params,
+        desc_prime: jnp.ndarray,
         transitions: Transition,
     ) -> jnp.ndarray:
         """Policy loss function for TD3 agent"""
         action = policy_fn(policy_params, transitions.obs)
-        q_value = critic_fn(
-            critic_params, transitions.obs, action, transitions.desc_prime
-        )
+        q_value = critic_fn(critic_params, transitions.obs, action, desc_prime)
         q1_action = jnp.take(q_value, jnp.asarray([0]), axis=-1)
         policy_loss = -jnp.mean(q1_action)
         return policy_loss
@@ -157,11 +157,12 @@ def make_td3_loss_dc_fn(
         target_actor_params: Params,
         target_critic_params: Params,
         transitions: Transition,
-        key: RNGKey,
+        random_key: RNGKey,
     ) -> jnp.ndarray:
         """Descriptor-conditioned critic loss function for TD3 agent"""
         noise = (
-            jax.random.normal(key, shape=transitions.actions.shape) * policy_noise
+            jax.random.normal(random_key, shape=transitions.actions.shape)
+            * policy_noise
         ).clip(-noise_clip, noise_clip)
 
         next_action = (
@@ -234,7 +235,7 @@ def td3_critic_loss_fn(
     reward_scaling: float,
     discount: float,
     transitions: Transition,
-    key: RNGKey,
+    random_key: RNGKey,
 ) -> jnp.ndarray:
     """Critics loss function for TD3 agent.
 
@@ -254,7 +255,7 @@ def td3_critic_loss_fn(
         Return the loss function used to train the critic in TD3.
     """
     noise = (
-        jax.random.normal(key, shape=transitions.actions.shape) * policy_noise
+        jax.random.normal(random_key, shape=transitions.actions.shape) * policy_noise
     ).clip(-noise_clip, noise_clip)
 
     next_action = (policy_fn(target_policy_params, transitions.next_obs) + noise).clip(


### PR DESCRIPTION
Related issues: [refer to issues]

Updated the qpg_emitter and dcrl_emitter with improved vram efficiency. This is achieved by sampling transition batch iteration by iteration and making the transition batch shared across the off-spring batch in PG variation.

This PR introduces:
- changing the state_update and emit_pg in qpg_emitter.py
- changing the state_update and emit_pg in dcrl_emitter.py
- changing the make_td3_dc_losses (decoupling desc_prime from transitions) in td3_loss.py
