### PR TITLE
Custom Repertoire MAPElites

### DIFF
--- a/qdax/core/custom_repertoire_map_elites.py
+++ b/qdax/core/custom_repertoire_map_elites.py
@@ -1,0 +1,104 @@
+"""Core components of the MAP-Elites algorithm."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any, Callable, Optional, Tuple
+
+import jax
+
+from qdax.core.map_elites import MAPElites
+
+from qdax.core.containers.mapelites_repertoire import MapElitesRepertoire
+
+from qdax.core.emitters.emitter import Emitter, EmitterState
+
+from qdax.custom_types import (
+    Centroid,
+    Descriptor,
+    ExtraScores,
+    Fitness,
+    Genotype,
+    Metrics,
+    RNGKey,
+)
+
+
+class CustomRepertoireMAPElites(MAPElites):
+    """Core elements of the MAP-Elites algorithm, with the ability to use custom repertoires.
+
+    Args:
+        scoring_function: a function that takes a batch of genotypes and compute
+            their fitnesses and descriptors
+        emitter: an emitter is used to suggest offsprings given a MAPELites
+            repertoire. It has two compulsory functions. A function that takes
+            emits a new population, and a function that update the internal state
+            of the emitter.
+        metrics_function: a function that takes a MAP-Elites repertoire and compute
+            any useful metric to track its evolution
+        repertoire_init: a function that initializes the MAP-Elites repertoire
+    """
+
+    def __init__(
+        self,
+        scoring_function: Callable[
+            [Genotype, RNGKey], Tuple[Fitness, Descriptor, ExtraScores]
+        ],
+        emitter: Emitter,
+        metrics_function: Callable[[MapElitesRepertoire], Metrics],
+        repertoire_init: Callable[
+            [Genotype, Fitness, Descriptor, Centroid, ExtraScores], MapElitesRepertoire
+        ] = MapElitesRepertoire.init,
+    ) -> None:
+        self._scoring_function = scoring_function
+        self._emitter = emitter
+        self._metrics_function = metrics_function
+        self._repertoire_init = repertoire_init
+
+    @partial(jax.jit, static_argnames=("self",))
+    def init(
+        self,
+        genotypes: Genotype,
+        centroids: Centroid,
+        key: RNGKey,
+    ) -> Tuple[MapElitesRepertoire, Optional[EmitterState]]:
+        """
+        Initialize a Map-Elites repertoire with an initial population of genotypes.
+        Requires the definition of centroids that can be computed with any method
+        such as CVT or Euclidean mapping.
+
+        Args:
+            genotypes: initial genotypes, pytree in which leaves
+                have shape (batch_size, num_features)
+            centroids: tessellation centroids of shape (batch_size, num_descriptors)
+            key: a random key used for stochastic operations.
+
+        Returns:
+            An initialized MAP-Elite repertoire with the initial state of the emitter,
+            and a random key.
+        """
+        # score initial genotypes
+        key, subkey = jax.random.split(key)
+        fitnesses, descriptors, extra_scores = self._scoring_function(genotypes, subkey)
+
+        # init the repertoire
+        repertoire = self._repertoire_init(
+            genotypes=genotypes,
+            fitnesses=fitnesses,
+            descriptors=descriptors,
+            centroids=centroids,
+            extra_scores=extra_scores,
+        )
+
+        # get initial state of the emitter
+        key, subkey = jax.random.split(key)
+        emitter_state = self._emitter.init(
+            key=subkey,
+            repertoire=repertoire,
+            genotypes=genotypes,
+            fitnesses=fitnesses,
+            descriptors=descriptors,
+            extra_scores=extra_scores,
+        )
+
+        return repertoire, emitter_state

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -33,9 +33,9 @@ def get_mixing_emitter(batch_size: int) -> MixingEmitter:
 
 
 @pytest.mark.parametrize(
-    "env_name, batch_size",
-    [("walker2d_uni", 1), ("walker2d_uni", 10), ("hopper_uni", 10)],
-    [False, True]
+    "env_name, batch_size, custom_repertoire",
+    [("walker2d_uni", 1, False), ("walker2d_uni", 10, False), ("hopper_uni", 10, False),
+     ("walker2d_uni", 1, True), ("walker2d_uni", 10, True), ("hopper_uni", 10, True)],
 )
 def test_map_elites(env_name: str, batch_size: int, custom_repertoire=False) -> None:
     batch_size = batch_size

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -37,7 +37,7 @@ def get_mixing_emitter(batch_size: int) -> MixingEmitter:
     [("walker2d_uni", 1, False), ("walker2d_uni", 10, False), ("hopper_uni", 10, False),
      ("walker2d_uni", 1, True), ("walker2d_uni", 10, True), ("hopper_uni", 10, True)],
 )
-def test_map_elites(env_name: str, batch_size: int, custom_repertoire=False) -> None:
+def test_map_elites(env_name: str, batch_size: int, custom_repertoire: bool) -> None:
     batch_size = batch_size
     env_name = env_name
     episode_length = 100

--- a/tests/core_test/map_elites_test.py
+++ b/tests/core_test/map_elites_test.py
@@ -35,6 +35,7 @@ def get_mixing_emitter(batch_size: int) -> MixingEmitter:
 @pytest.mark.parametrize(
     "env_name, batch_size",
     [("walker2d_uni", 1), ("walker2d_uni", 10), ("hopper_uni", 10)],
+    [False, True]
 )
 def test_map_elites(env_name: str, batch_size: int, custom_repertoire=False) -> None:
     batch_size = batch_size

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -17,13 +17,14 @@ from qdax.core.neuroevolution.buffers.buffer import QDTransition
 from qdax.core.neuroevolution.networks.networks import MLP
 from qdax.custom_types import EnvState, Params, RNGKey
 from qdax.tasks.brax_envs import scoring_function_brax_envs
-
+from qdax.core.custom_repertoire_map_elites import CustomRepertoireMAPElites
+from qdax.core.containers.mels_repertoire import MELSRepertoire
 
 @pytest.mark.parametrize(
     "env_name, batch_size",
     [("walker2d_uni", 1), ("walker2d_uni", 10), ("hopper_uni", 10)],
 )
-def test_mels(env_name: str, batch_size: int) -> None:
+def test_mels(env_name: str, batch_size: int, custom_repertoire=False) -> None:
     batch_size = batch_size
     env_name = env_name
     num_samples = 5
@@ -118,14 +119,6 @@ def test_mels(env_name: str, batch_size: int) -> None:
 
         return {"qd_score": qd_score, "max_fitness": max_fitness, "coverage": coverage}
 
-    # Instantiate ME-LS.
-    mels = MELS(
-        scoring_function=scoring_fn,
-        emitter=mixing_emitter,
-        metrics_function=metrics_fn,
-        num_samples=num_samples,
-    )
-
     # Compute the centroids
     key, subkey = jax.random.split(key)
     centroids = compute_cvt_centroids(
@@ -136,6 +129,22 @@ def test_mels(env_name: str, batch_size: int) -> None:
         maxval=max_descriptor,
         key=subkey,
     )
+
+    if custom_repertoire:
+        mels = CustomRepertoireMAPElites(
+            scoring_function=scoring_fn,
+            emitter=mixing_emitter,
+            metrics_function=metrics_fn,
+            repertoire_init=MELSRepertoire.init
+        )
+    else:
+        # Instantiate ME-LS.
+        mels = MELS(
+            scoring_function=scoring_fn,
+            emitter=mixing_emitter,
+            metrics_function=metrics_fn,
+            num_samples=num_samples,
+        )
 
     # Compute initial repertoire
     key, subkey = jax.random.split(key)
@@ -157,4 +166,5 @@ def test_mels(env_name: str, batch_size: int) -> None:
 
 
 if __name__ == "__main__":
-    test_mels(env_name="pointmaze", batch_size=10)
+    test_mels(env_name="pointmaze", batch_size=10, custom_repertoire=False)
+    test_mels(env_name="pointmaze", batch_size=10, custom_repertoire=True)

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -23,6 +23,7 @@ from qdax.core.containers.mels_repertoire import MELSRepertoire
 @pytest.mark.parametrize(
     "env_name, batch_size",
     [("walker2d_uni", 1), ("walker2d_uni", 10), ("hopper_uni", 10)],
+    [False, True]
 )
 def test_mels(env_name: str, batch_size: int, custom_repertoire=False) -> None:
     batch_size = batch_size

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -25,7 +25,7 @@ from qdax.core.containers.mels_repertoire import MELSRepertoire
     [("walker2d_uni", 1, False), ("walker2d_uni", 10, False), ("hopper_uni", 10, False),
      ("walker2d_uni", 1, True), ("walker2d_uni", 10, True), ("hopper_uni", 10, True)],
 )
-def test_mels(env_name: str, batch_size: int, custom_repertoire=False) -> None:
+def test_mels(env_name: str, batch_size: int, custom_repertoire: bool) -> None:
     batch_size = batch_size
     env_name = env_name
     num_samples = 5

--- a/tests/core_test/mels_test.py
+++ b/tests/core_test/mels_test.py
@@ -21,9 +21,9 @@ from qdax.core.custom_repertoire_map_elites import CustomRepertoireMAPElites
 from qdax.core.containers.mels_repertoire import MELSRepertoire
 
 @pytest.mark.parametrize(
-    "env_name, batch_size",
-    [("walker2d_uni", 1), ("walker2d_uni", 10), ("hopper_uni", 10)],
-    [False, True]
+    "env_name, batch_size, custom_repertoire",
+    [("walker2d_uni", 1, False), ("walker2d_uni", 10, False), ("hopper_uni", 10, False),
+     ("walker2d_uni", 1, True), ("walker2d_uni", 10, True), ("hopper_uni", 10, True)],
 )
 def test_mels(env_name: str, batch_size: int, custom_repertoire=False) -> None:
     batch_size = batch_size

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -20,7 +20,7 @@ from qdax.core.containers.mome_repertoire import MOMERepertoire
 from qdax.core.custom_repertoire_map_elites import CustomRepertoireMAPElites
 
 
-@pytest.mark.parametrize("num_descriptors", [1, 2])
+@pytest.mark.parametrize("num_descriptors", [1, 2], [False, True])
 def test_mome(num_descriptors: int, custom_repertoire=False) -> None:
 
     pareto_front_max_length = 50

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -20,7 +20,9 @@ from qdax.core.containers.mome_repertoire import MOMERepertoire
 from qdax.core.custom_repertoire_map_elites import CustomRepertoireMAPElites
 
 
-@pytest.mark.parametrize("num_descriptors", [1, 2], [False, True])
+@pytest.mark.parametrize("num_descriptors, custom_repertoire", 
+                         [(1, False), (2, False), (1, True), (2, True)]
+                         )
 def test_mome(num_descriptors: int, custom_repertoire=False) -> None:
 
     pareto_front_max_length = 50

--- a/tests/core_test/mome_test.py
+++ b/tests/core_test/mome_test.py
@@ -23,7 +23,7 @@ from qdax.core.custom_repertoire_map_elites import CustomRepertoireMAPElites
 @pytest.mark.parametrize("num_descriptors, custom_repertoire", 
                          [(1, False), (2, False), (1, True), (2, True)]
                          )
-def test_mome(num_descriptors: int, custom_repertoire=False) -> None:
+def test_mome(num_descriptors: int, custom_repertoire: bool) -> None:
 
     pareto_front_max_length = 50
     num_variables = 120


### PR DESCRIPTION
Related issues: #222 
**Might conflict with the ask/tell PR #221 as they both change the init**

This PR introduces:
- CustomRepertoireMAPElites class that allows to build ME with a custom repertoire init function
- Changed ME / MELS / MOME test files to run twice, with the standard and custom ME building ways

## Checks

- [x] a clear description of the PR has been added
- [x] sufficient tests have been written
- [ ] example notebook have been added to the repo
  - It's mostly a dev tool, do we need a notebook for it? 
- [ ] all example notebooks have been verified to execute without errors
- [x] clean docstrings and comments have been written
- [x] relevant section have been added to the documentation
- [x] if any issue/observation has been discovered, a new issue has been opened
- [x] the source branch is `develop` if this PR introduces a new feature

## Future improvements

- Set it as the default MAPElites class
- Remove MELS / MOME builders and use this one in example notebooks
