### PR TITLE
Feature vram opt

### DIFF
--- a/qdax/core/emitters/dcrl_emitter.py
+++ b/qdax/core/emitters/dcrl_emitter.py
@@ -217,7 +217,7 @@ class DCRLEmitter(Emitter):
         return jnp.exp(
             -jnp.linalg.norm(descs_1 - descs_2, axis=-1) / self._config.lengthscale
         )
-    
+
     @partial(jax.jit, static_argnames=("self",))
     def _normalize_desc(self, desc: Descriptor) -> Descriptor:
         return (
@@ -292,7 +292,7 @@ class DCRLEmitter(Emitter):
         key, subkey = jax.random.split(key)
         sub_repertoire = repertoire.select(
             key, self._config.dcrl_batch_size, selector=self._selector
-            )
+        )
         parents_pg = sub_repertoire.genotypes
         descs_pg = sub_repertoire.descriptors
         genotypes_pg = self.emit_pg(emitter_state, parents_pg, descs_pg)
@@ -300,10 +300,8 @@ class DCRLEmitter(Emitter):
         # Actor injection emitter
         descs_ai = repertoire.select(
             subkey, self._config.ai_batch_size, selector=self._selector
-            ).descriptors
-        descs_ai = descs_ai.reshape(
-            descs_ai.shape[0], self._env.descriptor_length
-        )
+        ).descriptors
+        descs_ai = descs_ai.reshape(descs_ai.shape[0], self._env.descriptor_length)
         genotypes_ai = self.emit_ai(emitter_state, descs_ai)
 
         # Concatenate PG and AI genotypes
@@ -491,7 +489,6 @@ class DCRLEmitter(Emitter):
         )
 
         return final_emitter_state  # type: ignore
-    
 
     @partial(jax.jit, static_argnames=("self",))
     def _scan_update_critic(
@@ -627,8 +624,7 @@ class DCRLEmitter(Emitter):
 
         # sample transitions
         transitions = emitter_state.replay_buffer.sample(
-            subkey, 
-            self._config.batch_size * (self._config.policy_delay + 1)
+            subkey, self._config.batch_size * (self._config.policy_delay + 1)
         )
         transitions = jax.tree.map(
             lambda x: jnp.reshape(
@@ -691,7 +687,6 @@ class DCRLEmitter(Emitter):
         )
 
         return new_emitter_state, ()
-
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(

--- a/qdax/core/emitters/dcrl_emitter.py
+++ b/qdax/core/emitters/dcrl_emitter.py
@@ -4,17 +4,15 @@ in JAX for Brax environments.
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, Tuple
+from typing import Any, Tuple
 
 import flax.linen as nn
 import jax
 import optax
 from jax import numpy as jnp
 
-from qdax.core.containers.mapelites_repertoire import MapElitesRepertoire
 from qdax.core.containers.repertoire import Repertoire
 from qdax.core.emitters.emitter import Emitter, EmitterState
-from qdax.core.emitters.repertoire_selectors.selector import Selector
 from qdax.core.neuroevolution.buffers.buffer import DCRLTransition, ReplayBuffer
 from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_dc_fn
 from qdax.core.neuroevolution.networks.networks import QModuleDC
@@ -57,7 +55,6 @@ class DCRLEmitterState(EmitterState):
     target_actor_params: Params
     replay_buffer: ReplayBuffer
     key: RNGKey
-    steps: jnp.ndarray
 
 
 class DCRLEmitter(Emitter):
@@ -72,12 +69,13 @@ class DCRLEmitter(Emitter):
         policy_network: nn.Module,
         actor_network: nn.Module,
         env: QDEnv,
-        selector: Optional[Selector] = None,
     ) -> None:
         self._config = config
         self._env = env
-        self._policy_network = policy_network
         self._actor_network = actor_network
+        self._actor_critic_iterations = int(
+            config.num_critic_training_steps / config.policy_delay
+        )  # actor and critic training are packed into a single function
 
         # Init Critics
         critic_network = QModuleDC(
@@ -111,8 +109,6 @@ class DCRLEmitter(Emitter):
             learning_rate=self._config.policy_learning_rate
         )
 
-        self._selector = selector
-
     @property
     def batch_size(self) -> int:
         """
@@ -123,11 +119,7 @@ class DCRLEmitter(Emitter):
 
     @property
     def use_all_data(self) -> bool:
-        """Whether to use all data or not when used along other emitters.
-
-        QualityPGEmitter uses the transitions from the genotypes that were generated
-        by other emitters.
-        """
+        """Whether to use all data or not when used along other emitters"""
         return True
 
     def init(
@@ -138,7 +130,7 @@ class DCRLEmitter(Emitter):
         fitnesses: Fitness,
         descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> DCRLEmitterState:
+    ) -> Tuple[DCRLEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
@@ -146,7 +138,7 @@ class DCRLEmitter(Emitter):
             key: A random key.
 
         Returns:
-            The initial state of the PGAMEEmitter.
+            The initial state of the PGAMEEmitter, a new random key.
         """
 
         observation_size = jax.tree.leaves(genotypes)[1].shape[1]
@@ -187,7 +179,7 @@ class DCRLEmitter(Emitter):
         transitions = extra_scores["transitions"]
         episode_length = transitions.obs.shape[1]
 
-        desc = jnp.repeat(descriptors[:, jnp.newaxis, :], episode_length, axis=1)
+        desc = jnp.repeat(descriptors[:, None, :], episode_length, axis=1)
         desc_normalized = jax.vmap(jax.vmap(self._normalize_desc))(desc)
 
         transitions = transitions.replace(
@@ -206,10 +198,9 @@ class DCRLEmitter(Emitter):
             target_actor_params=target_actor_params,
             replay_buffer=replay_buffer,
             key=subkey,
-            steps=jnp.array(0),
         )
 
-        return emitter_state
+        return emitter_state, key
 
     @partial(jax.jit, static_argnames=("self",))
     def _similarity(self, descs_1: Descriptor, descs_2: Descriptor) -> jnp.array:
@@ -223,7 +214,7 @@ class DCRLEmitter(Emitter):
         return jnp.exp(
             -jnp.linalg.norm(descs_1 - descs_2, axis=-1) / self._config.lengthscale
         )
-
+    
     @partial(jax.jit, static_argnames=("self",))
     def _normalize_desc(self, desc: Descriptor) -> Descriptor:
         return (
@@ -274,14 +265,17 @@ class DCRLEmitter(Emitter):
         actor_dc_params["params"]["Dense_0"]["bias"] = equivalent_bias
         return actor_dc_params
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit(
         self,
-        repertoire: MapElitesRepertoire,
+        repertoire: Repertoire,
         emitter_state: DCRLEmitterState,
         key: RNGKey,
-    ) -> Tuple[Genotype, ExtraScores]:
-        """Do a step of PG emission.
+    ) -> Tuple[Genotype, ExtraScores, RNGKey]:
+        """Do a step of policy-gradient and actor-injection emission.
 
         Args:
             repertoire: the current repertoire of genotypes
@@ -292,26 +286,23 @@ class DCRLEmitter(Emitter):
             A batch of offspring, the new emitter state and a new key.
         """
         # PG emitter
-        key, subkey = jax.random.split(key)
-        selected_sub_repertoire = repertoire.select(
-            subkey, num_samples=self._config.dcrl_batch_size, selector=self._selector
+        parents_pg, descs_pg, key = repertoire.sample_with_descs(
+            key, self._config.dcrl_batch_size
         )
-        parents_pg = selected_sub_repertoire.genotypes
-        descs_pg = selected_sub_repertoire.descriptors
+        key, subkey = jax.random.split(key)
+        emitter_state = emitter_state.replace(key=subkey)
         genotypes_pg = self.emit_pg(emitter_state, parents_pg, descs_pg)
 
         # Actor injection emitter
-        key, subkey = jax.random.split(key)
-        descs_ai = repertoire.select(
-            key, self._config.ai_batch_size, selector=self._selector
-        ).descriptors
-
-        descs_ai = descs_ai.reshape(descs_ai.shape[0], self._env.descriptor_length)
+        _, descs_ai, key = repertoire.sample_with_descs(key, self._config.ai_batch_size)
+        descs_ai = descs_ai.reshape(
+            descs_ai.shape[0], self._env.descriptor_length
+        )
         genotypes_ai = self.emit_ai(emitter_state, descs_ai)
 
         # Concatenate PG and AI genotypes
         genotypes = jax.tree.map(
-            lambda x1, x2: jnp.concatenate((x1, x2), axis=0), genotypes_pg, genotypes_ai
+            lambda x, y: jnp.concatenate((x, y), axis=0), genotypes_pg, genotypes_ai
         )
 
         return (
@@ -319,7 +310,10 @@ class DCRLEmitter(Emitter):
             {"desc_prime": jnp.concatenate([descs_pg, descs_ai], axis=0)},
         )
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_pg(
         self,
         emitter_state: DCRLEmitterState,
@@ -338,15 +332,56 @@ class DCRLEmitter(Emitter):
         Returns:
             A new set of offsprings.
         """
-        mutation_fn = partial(
-            self._mutation_function_pg,
-            emitter_state=emitter_state,
+        # normalize the intended descriptors and prepare them for concatenation
+        descs_prime_normalized = jnp.tile(
+            jax.vmap(self._normalize_desc)(descs), self._config.batch_size
+        ).reshape(self._config.dcrl_batch_size, self._config.batch_size, -1)
+
+        # create a batch of policy optimizer states
+        policy_opt_states = jax.vmap(self._policies_optimizer.init)(parents)
+
+        # prepare the batched policy update function with vmapping
+        batched_policy_update_fn = jax.vmap(
+            partial(self._update_policy, critic_params=emitter_state.critic_params),
+            in_axes=(0, 0, 0, None),
         )
-        offsprings = jax.vmap(mutation_fn)(parents, descs)
 
-        return offsprings
+        def scan_update_policies(
+            carry: Tuple[Params, optax.OptState, jnp.ndarray, RNGKey],
+            _: None,
+        ) -> Tuple[Tuple[Params, optax.OptState, jnp.ndarray, RNGKey], Any]:
 
-    @partial(jax.jit, static_argnames=("self",))
+            (policy_params, policy_opt_state, desc_prime, key) = carry
+
+            # sample a mini-batch of data from the replay-buffer
+            transitions, key = emitter_state.replay_buffer.sample(
+                key, self._config.batch_size
+            )
+            (
+                new_policy_params,
+                new_policy_opt_states,
+            ) = batched_policy_update_fn(
+                policy_params, policy_opt_state, desc_prime, transitions
+            )
+            return (new_policy_params, new_policy_opt_states, desc_prime, key), ()
+
+        (
+            final_policy_params,
+            policy_opt_state,
+            desc_prime,
+            key,
+        ), _ = jax.lax.scan(
+            scan_update_policies,
+            (parents, policy_opt_states, descs_prime_normalized, emitter_state.key),
+            length=self._config.num_pg_training_steps,
+        )
+
+        return final_policy_params
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_ai(self, emitter_state: DCRLEmitterState, descs: Descriptor) -> Genotype:
         """Emit the offsprings generated through pg mutation.
 
@@ -381,7 +416,10 @@ class DCRLEmitter(Emitter):
         """
         return emitter_state.actor_params
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def state_update(
         self,
         emitter_state: DCRLEmitterState,
@@ -435,154 +473,81 @@ class DCRLEmitter(Emitter):
         )
 
         # Add transitions to replay buffer
-        replay_buffer = emitter_state.replay_buffer.insert(transitions)
-        emitter_state = emitter_state.replace(replay_buffer=replay_buffer)
-
-        # sample transitions from the replay buffer
-        key, subkey = jax.random.split(emitter_state.key)
-        transitions = replay_buffer.sample(
-            subkey, self._config.num_critic_training_steps * self._config.batch_size
+        emitter_state = emitter_state.replace(
+            replay_buffer=emitter_state.replay_buffer.insert(transitions)
         )
-        transitions = jax.tree.map(
-            lambda x: jnp.reshape(
-                x,
-                (
-                    self._config.num_critic_training_steps,
-                    self._config.batch_size,
-                    *x.shape[1:],
-                ),
-            ),
-            transitions,
-        )
-        transitions = transitions.replace(
-            rewards=self._similarity(transitions.desc, transitions.desc_prime)
-            * transitions.rewards
-        )
-        emitter_state = emitter_state.replace(key=key)
 
-        def scan_train_critics(
-            carry: DCRLEmitterState,
-            transitions: DCRLTransition,
-        ) -> Tuple[DCRLEmitterState, Any]:
-            emitter_state = carry
-            new_emitter_state = self._train_critics(emitter_state, transitions)
-            return new_emitter_state, ()
-
-        # Train critics and greedy actor
-        emitter_state, _ = jax.lax.scan(
-            scan_train_critics,
+        # Conduct Actor-Critic training
+        new_emitter_state, _ = jax.lax.scan(
+            self._scan_actor_critic_training,
             emitter_state,
-            transitions,
-            length=self._config.num_critic_training_steps,
+            length=self._actor_critic_iterations,
         )
 
-        return emitter_state  # type: ignore
+        return new_emitter_state
 
     @partial(jax.jit, static_argnames=("self",))
-    def _train_critics(
-        self, emitter_state: DCRLEmitterState, transitions: DCRLTransition
-    ) -> DCRLEmitterState:
-        """Apply one gradient step to critics and to the greedy actor
-        (contained in carry in training_state), then soft update target critics
-        and target actor.
-
-        Those updates are very similar to those made in TD3.
+    def _scan_update_critic(
+        self,
+        carry: Tuple[Params, Params, optax.OptState, Params, RNGKey],
+        transitions: DCRLTransition,
+    ) -> Tuple[Tuple[Params, Params, optax.OptState, Params, RNGKey], Any]:
+        """A scan-ready function to update the critic network parameters
+        with one gradient step.
 
         Args:
-            emitter_state: actual emitter state
+            carry: packed carry containing critic parameters, target critic
+                parameters, critic optimiser state, target actor parameters,
+                and the random key.
+            transitions: a mini-batch of DCRLtransitions for gradient computation
 
         Returns:
-            New emitter state where the critic and the greedy actor have been
-            updated. Optimizer states have also been updated in the process.
+            new_carry: new carry containing updated parameters (target actor
+                parameters is unchanged).
+            empty tuple: compulsory signature for jax.lax.scan
         """
-        key, subkey = jax.random.split(emitter_state.key)
-
-        # Update Critic
+        # unpack the carry
         (
-            critic_opt_state,
             critic_params,
             target_critic_params,
-        ) = self._update_critic(
-            critic_params=emitter_state.critic_params,
-            target_critic_params=emitter_state.target_critic_params,
-            target_actor_params=emitter_state.target_actor_params,
-            critic_opt_state=emitter_state.critic_opt_state,
-            transitions=transitions,
-            key=subkey,
-        )
-
-        # Update greedy actor
-        (
-            actor_opt_state,
-            actor_params,
+            critic_opt_state,
             target_actor_params,
-        ) = jax.lax.cond(
-            emitter_state.steps % self._config.policy_delay == 0,
-            lambda x: self._update_actor(*x),
-            lambda _: (
-                emitter_state.actor_opt_state,
-                emitter_state.actor_params,
-                emitter_state.target_actor_params,
-            ),
-            operand=(
-                emitter_state.actor_params,
-                emitter_state.actor_opt_state,
-                emitter_state.target_actor_params,
-                emitter_state.critic_params,
-                transitions,
-            ),
-        )
+            key,
+        ) = carry
 
-        # Create new training state
-        new_emitter_state = emitter_state.replace(
-            critic_params=critic_params,
-            critic_opt_state=critic_opt_state,
-            actor_params=actor_params,
-            actor_opt_state=actor_opt_state,
-            target_critic_params=target_critic_params,
-            target_actor_params=target_actor_params,
-            key=key,
-            steps=emitter_state.steps + 1,
-        )
-
-        return new_emitter_state  # type: ignore
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _update_critic(
-        self,
-        critic_params: Params,
-        target_critic_params: Params,
-        target_actor_params: Params,
-        critic_opt_state: Params,
-        transitions: DCRLTransition,
-        key: RNGKey,
-    ) -> Tuple[Params, Params, Params]:
-
-        # compute loss and gradients
+        # compute critic gradients
         key, subkey = jax.random.split(key)
         critic_gradient = jax.grad(self._critic_loss_fn)(
             critic_params,
             target_actor_params,
             target_critic_params,
             transitions,
-            key,
+            subkey,
         )
-        critic_updates, critic_opt_state = self._critic_optimizer.update(
+        critic_updates, new_critic_opt_state = self._critic_optimizer.update(
             critic_gradient, critic_opt_state
         )
 
         # update critic
-        critic_params = optax.apply_updates(critic_params, critic_updates)
+        new_critic_params = optax.apply_updates(critic_params, critic_updates)
 
         # Soft update of target critic network
-        target_critic_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_critic_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_critic_params,
-            critic_params,
+            new_critic_params,
+        )
+        # pack into new carry
+        new_carry = (
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
         )
 
-        return critic_opt_state, critic_params, target_critic_params
+        return new_carry, ()
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_actor(
@@ -593,6 +558,22 @@ class DCRLEmitter(Emitter):
         critic_params: Params,
         transitions: DCRLTransition,
     ) -> Tuple[optax.OptState, Params, Params]:
+        """Function to update the DC-actor with one Policy-Gradient step.
+
+        Args:
+            actor_params: neural network parameters of the DC-actor.
+            actor_opt_state: optimiser state of the actor.
+            target_actor_params: target actor parameters (used in TD3 to
+                smooth the actor-critic learning).
+            critic_params: the parameters of the critic networks which plays
+                as a differentiable target.
+            transitions: a mini-batch of DCRLtransitions.
+
+        Returns:
+            new_actor_params: new actor parameters after taking the PG step
+            new_target_actor_params: new target actor parameters (soft-tau update)
+            new_actor_opt_state: updated optimiser state
+        """
 
         # Update greedy actor
         policy_gradient = jax.grad(self._actor_loss_fn)(
@@ -602,64 +583,47 @@ class DCRLEmitter(Emitter):
         )
         (
             policy_updates,
-            actor_opt_state,
+            new_actor_opt_state,
         ) = self._actor_optimizer.update(policy_gradient, actor_opt_state)
-        actor_params = optax.apply_updates(actor_params, policy_updates)
+        new_actor_params = optax.apply_updates(actor_params, policy_updates)
 
         # Soft update of target greedy actor
-        target_actor_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_actor_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_actor_params,
-            actor_params,
+            new_actor_params,
         )
-
-        return (
-            actor_opt_state,
-            actor_params,
-            target_actor_params,
-        )
+        return new_actor_params, new_target_actor_params, new_actor_opt_state
 
     @partial(jax.jit, static_argnames=("self",))
-    def _mutation_function_pg(
-        self,
-        policy_params: Genotype,
-        descs: Descriptor,
-        emitter_state: DCRLEmitterState,
-    ) -> Genotype:
-        """Apply pg mutation to a policy via multiple steps of gradient descent.
-        First, update the rewards to be diversity rewards, then apply the gradient
-        steps.
+    def _scan_actor_critic_training(
+        self, carry: DCRLEmitterState, _: None
+    ) -> Tuple[DCRLEmitterState, Tuple]:
+        """
+        Perform a few (policy delay) steps of critic followed by one step of
+        actor training, all packed into a single scan-ready function.
+        Transition data are sampled step-by-step to promote memory efficiency.
 
         Args:
-            policy_params: a policy, supposed to be a differentiable neural
-                network.
-            emitter_state: the current state of the emitter, containing among others,
-                the replay buffer, the critic.
+            carry: emitter state
+            _: None
 
         Returns:
-            The updated params of the neural network.
+            new_emitter_state: new emitter state containing updated network
+                parameters as the new carry.
+            empty tuple: compulsory signature for jax.lax.scan
         """
-        key, subkey = jax.random.split(emitter_state.key)
-        # Get transitions
-        transitions = emitter_state.replay_buffer.sample(
-            subkey,
-            sample_size=self._config.num_pg_training_steps * self._config.batch_size,
-        )
-        descs_prime = jnp.tile(
-            descs, (self._config.num_pg_training_steps * self._config.batch_size, 1)
-        )
-        descs_prime_normalized = jax.vmap(self._normalize_desc)(descs_prime)
-        transitions = transitions.replace(
-            rewards=self._similarity(transitions.desc, descs_prime_normalized)
-            * transitions.rewards,
-            desc_prime=descs_prime_normalized,
+
+        emitter_state = carry
+        transitions, key = emitter_state.replay_buffer.sample(
+            emitter_state.key, self._config.batch_size * (self._config.policy_delay + 1)
         )
         transitions = jax.tree.map(
             lambda x: jnp.reshape(
                 x,
                 (
-                    self._config.num_pg_training_steps,
+                    self._config.policy_delay + 1,
                     self._config.batch_size,
                     *x.shape[1:],
                 ),
@@ -667,94 +631,96 @@ class DCRLEmitter(Emitter):
             transitions,
         )
 
-        # Replace key
-        emitter_state = emitter_state.replace(key=key)
+        # rescale rewards by descriptor similarity
+        transitions = transitions.replace(
+            rewards=self._similarity(transitions.desc, transitions.desc_prime)
+            * transitions.rewards
+        )
 
-        # Define new policy optimizer state
-        policy_opt_state = self._policies_optimizer.init(policy_params)
+        # split the transitions for critic and actor
+        critic_data = jax.tree.map(lambda x: x[:-1], transitions)
+        actor_data = jax.tree.map(lambda x: x[-1], transitions)
 
-        def scan_train_policy(
-            carry: Tuple[DCRLEmitterState, Genotype, optax.OptState],
-            transitions: DCRLTransition,
-        ) -> Tuple[Tuple[DCRLEmitterState, Genotype, optax.OptState], Any]:
-            emitter_state, policy_params, policy_opt_state = carry
-            (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_opt_state,
-            ) = self._train_policy(
-                emitter_state,
-                policy_params,
-                policy_opt_state,
-                transitions,
-            )
-            return (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_opt_state,
-            ), ()
-
+        # scan training critics
         (
-            emitter_state,
-            policy_params,
-            policy_opt_state,
-        ), _ = jax.lax.scan(
-            scan_train_policy,
-            (emitter_state, policy_params, policy_opt_state),
-            transitions,
-            length=self._config.num_pg_training_steps,
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
+        ), () = jax.lax.scan(
+            self._scan_update_critic,
+            (
+                emitter_state.critic_params,
+                emitter_state.target_critic_params,
+                emitter_state.critic_opt_state,
+                emitter_state.target_actor_params,
+                key,
+            ),
+            critic_data,
         )
 
-        return policy_params
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _train_policy(
-        self,
-        emitter_state: DCRLEmitterState,
-        policy_params: Params,
-        policy_opt_state: optax.OptState,
-        transitions: DCRLTransition,
-    ) -> Tuple[DCRLEmitterState, Params, optax.OptState]:
-        """Apply one gradient step to a policy (called policy_params).
-
-        Args:
-            emitter_state: current state of the emitter.
-            policy_params: parameters corresponding to the weights and bias of
-                the neural network that defines the policy.
-
-        Returns:
-            The new emitter state and new params of the NN.
-        """
-        # update policy
-        policy_opt_state, policy_params = self._update_policy(
-            critic_params=emitter_state.critic_params,
-            policy_opt_state=policy_opt_state,
-            policy_params=policy_params,
-            transitions=transitions,
+        # train actor with one gradient step
+        (new_actor_params, new_target_actor_params, new_actor_opt_state) = (
+            self._update_actor(
+                emitter_state.actor_params,
+                emitter_state.actor_opt_state,
+                target_actor_params,
+                new_critic_params,
+                actor_data,
+            )
         )
 
-        return emitter_state, policy_params, policy_opt_state
+        new_emitter_state = emitter_state.replace(
+            critic_params=new_critic_params,
+            critic_opt_state=new_critic_opt_state,
+            actor_params=new_actor_params,
+            actor_opt_state=new_actor_opt_state,
+            target_critic_params=new_target_critic_params,
+            target_actor_params=new_target_actor_params,
+            key=key,
+        )
+
+        return new_emitter_state, ()
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(
         self,
-        critic_params: Params,
-        policy_opt_state: optax.OptState,
         policy_params: Params,
+        policy_opt_state: optax.OptState,
+        desc_prime: jnp.ndarray,
         transitions: DCRLTransition,
-    ) -> Tuple[optax.OptState, Params]:
+        critic_params: Params,
+    ) -> Tuple[Params, optax.OptState]:
+        """Perform one step of PG update on the off-spring policy.
+        This function is vmapped to mutate the entire batch of off-springs
+        in parallel.
 
-        # compute loss
+        Args:
+            policy_params: the parameters of the policy.
+            policy_opt_state: the optimiser state of the policy.
+            desc_prime: the normalised intended descriptor of the policy.
+            transitions: a mini-batch of transitions for gradient computation
+            critic_params: the parameters of the critic networks serving as
+                a differentiable target. This is fixed in each iteration.
+
+        Returns:
+            new_policy_params: new policy parameters
+            new_policy_opt_state: updated optimiser state
+        """
+
+        # Compute gradient
         policy_gradient = jax.grad(self._policy_loss_fn)(
             policy_params,
             critic_params,
+            desc_prime,
             transitions,
         )
-        # Compute gradient and update policies
+        # Update the policy
         (
             policy_updates,
-            policy_opt_state,
+            new_policy_opt_state,
         ) = self._policies_optimizer.update(policy_gradient, policy_opt_state)
-        policy_params = optax.apply_updates(policy_params, policy_updates)
+        new_policy_params = optax.apply_updates(policy_params, policy_updates)
 
-        return policy_opt_state, policy_params
+        return new_policy_params, new_policy_opt_state

--- a/qdax/core/emitters/dcrl_emitter.py
+++ b/qdax/core/emitters/dcrl_emitter.py
@@ -203,7 +203,7 @@ class DCRLEmitter(Emitter):
             key=subkey,
         )
 
-        return emitter_state, key
+        return emitter_state
 
     @partial(jax.jit, static_argnames=("self",))
     def _similarity(self, descs_1: Descriptor, descs_2: Descriptor) -> jnp.array:

--- a/qdax/core/emitters/dcrl_emitter.py
+++ b/qdax/core/emitters/dcrl_emitter.py
@@ -490,7 +490,7 @@ class DCRLEmitter(Emitter):
             length=self._actor_critic_iterations,
         )
 
-        return final_emitter_state
+        return final_emitter_state  # type: ignore
     
 
     @partial(jax.jit, static_argnames=("self",))

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -29,8 +29,6 @@ from qdax.custom_types import (
 )
 from qdax.environments.base_wrappers import QDEnv
 
-# print("hello")
-
 
 @dataclass
 class DiversityPGConfig(QualityPGConfig):

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -32,6 +32,7 @@ from qdax.custom_types import (
 )
 from qdax.environments.base_wrappers import QDEnv
 
+print("hello")
 
 @dataclass
 class DiversityPGConfig(QualityPGConfig):

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -31,6 +31,7 @@ from qdax.environments.base_wrappers import QDEnv
 
 # print("hello")
 
+
 @dataclass
 class DiversityPGConfig(QualityPGConfig):
     """Configuration for DiversityPG Emitter"""
@@ -76,7 +77,6 @@ class DiversityPGEmitter(QualityPGEmitter):
         self._config: DiversityPGConfig = config
         # define scoring function
         self._score_novelty = score_novelty
-
 
     def init(
         self,
@@ -136,7 +136,6 @@ class DiversityPGEmitter(QualityPGEmitter):
 
         return emitter_state
 
-
     @partial(jax.jit, static_argnames=("self",))
     def state_update(
         self,
@@ -176,7 +175,7 @@ class DiversityPGEmitter(QualityPGEmitter):
         # add transitions to the replay buffer and archive
         emitter_state = emitter_state.replace(
             replay_buffer=emitter_state.replay_buffer.insert(transitions),
-            archive=emitter_state.archive.insert(transitions.state_desc)
+            archive=emitter_state.archive.insert(transitions.state_desc),
         )
 
         # Conduct Actor-Critic training
@@ -187,7 +186,6 @@ class DiversityPGEmitter(QualityPGEmitter):
         )
 
         return final_emitter_state  # type: ignore
-
 
     @partial(jax.jit, static_argnames=("self",))
     def _scan_actor_critic_training(
@@ -219,7 +217,9 @@ class DiversityPGEmitter(QualityPGEmitter):
 
         # update the rewards - diversity rewards
         state_descriptors = transitions.state_desc
-        diversity_rewards = self._score_novelty(emitter_state.archive, state_descriptors)
+        diversity_rewards = self._score_novelty(
+            emitter_state.archive, state_descriptors
+        )
         transitions = transitions.replace(rewards=diversity_rewards)
 
         transitions = jax.tree.map(

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -18,6 +18,7 @@ from qdax.core.emitters.qpg_emitter import (
     QualityPGEmitter,
     QualityPGEmitterState,
 )
+from qdax.core.emitters.repertoire_selectors.selector import Selector
 from qdax.core.neuroevolution.buffers.buffer import QDTransition
 from qdax.custom_types import (
     Descriptor,
@@ -68,10 +69,11 @@ class DiversityPGEmitter(QualityPGEmitter):
         policy_network: nn.Module,
         env: QDEnv,
         score_novelty: Callable[[Archive, StateDescriptor], Reward],
+        selector: Optional[Selector] = None,
     ) -> None:
 
         # usual init operations from PGAME
-        super().__init__(config, policy_network, env)
+        super().__init__(config, policy_network, env, selector)
 
         self._config: DiversityPGConfig = config
         # define scoring function
@@ -209,11 +211,11 @@ class DiversityPGEmitter(QualityPGEmitter):
         """
 
         emitter_state = carry
-        key = emitter_state.key
+        key, subkey = jax.random.split(emitter_state.key)
 
         # sample transitions
         transitions = emitter_state.replay_buffer.sample(
-            key,
+            subkey,
             self._config.batch_size * (self._config.policy_delay + 1),
         )
 

--- a/qdax/core/emitters/dpg_emitter.py
+++ b/qdax/core/emitters/dpg_emitter.py
@@ -4,12 +4,11 @@ based on: https://arxiv.org/abs/2006.08505
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import flax.linen as nn
 import jax
 from jax import numpy as jnp
-import optax
 
 from qdax.core.containers.archive import Archive
 from qdax.core.containers.repertoire import Repertoire
@@ -19,20 +18,18 @@ from qdax.core.emitters.qpg_emitter import (
     QualityPGEmitterState,
 )
 from qdax.core.emitters.repertoire_selectors.selector import Selector
-from qdax.core.neuroevolution.buffers.buffer import QDTransition
 from qdax.custom_types import (
     Descriptor,
     ExtraScores,
     Fitness,
     Genotype,
-    Params,
     Reward,
     RNGKey,
     StateDescriptor,
 )
 from qdax.environments.base_wrappers import QDEnv
 
-print("hello")
+# print("hello")
 
 @dataclass
 class DiversityPGConfig(QualityPGConfig):

--- a/qdax/core/emitters/qpg_emitter.py
+++ b/qdax/core/emitters/qpg_emitter.py
@@ -12,10 +12,8 @@ import jax
 import optax
 from jax import numpy as jnp
 
-from qdax.core.containers.ga_repertoire import GARepertoire
 from qdax.core.containers.repertoire import Repertoire
 from qdax.core.emitters.emitter import Emitter, EmitterState
-from qdax.core.emitters.repertoire_selectors.selector import Selector
 from qdax.core.neuroevolution.buffers.buffer import QDTransition, ReplayBuffer
 from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_fn
 from qdax.core.neuroevolution.networks.networks import QModule
@@ -57,7 +55,6 @@ class QualityPGEmitterState(EmitterState):
     target_actor_params: Params
     replay_buffer: ReplayBuffer
     key: RNGKey
-    steps: jnp.ndarray
 
 
 class QualityPGEmitter(Emitter):
@@ -71,11 +68,12 @@ class QualityPGEmitter(Emitter):
         config: QualityPGConfig,
         policy_network: nn.Module,
         env: QDEnv,
-        selector: Optional[Selector] = None,
     ) -> None:
         self._config = config
         self._env = env
-        self._policy_network = policy_network
+        self._actor_critic_iterations = int(
+            config.num_critic_training_steps / config.policy_delay
+        )  # actor and critic training are packed into a single function
 
         # Init Critics
         critic_network = QModule(
@@ -104,8 +102,6 @@ class QualityPGEmitter(Emitter):
             learning_rate=self._config.policy_learning_rate
         )
 
-        self._selector = selector
-
     @property
     def batch_size(self) -> int:
         """
@@ -125,21 +121,21 @@ class QualityPGEmitter(Emitter):
 
     def init(
         self,
-        key: RNGKey,
+        random_key: RNGKey,
         repertoire: Repertoire,
         genotypes: Genotype,
         fitnesses: Fitness,
         descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> QualityPGEmitterState:
+    ) -> Tuple[QualityPGEmitterState, RNGKey]:
         """Initializes the emitter state.
 
         Args:
             genotypes: The initial population.
-            key: A random key.
+            random_key: A random key.
 
         Returns:
-            The initial state of the PGAMEEmitter.
+            The initial state of the PGAMEEmitter, a new random key.
         """
 
         observation_size = self._env.observation_size
@@ -147,16 +143,16 @@ class QualityPGEmitter(Emitter):
         descriptor_size = self._env.state_descriptor_length
 
         # Initialise critic, greedy actor and population
-        key, subkey = jax.random.split(key)
+        random_key, subkey = jax.random.split(random_key)
         fake_obs = jnp.zeros(shape=(observation_size,))
         fake_action = jnp.zeros(shape=(action_size,))
         critic_params = self._critic_network.init(
             subkey, obs=fake_obs, actions=fake_action
         )
-        target_critic_params = jax.tree.map(lambda x: x, critic_params)
+        target_critic_params = jax.tree_util.tree_map(lambda x: x, critic_params)
 
-        actor_params = jax.tree.map(lambda x: x[0], genotypes)
-        target_actor_params = jax.tree.map(lambda x: x[0], genotypes)
+        actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
+        target_actor_params = jax.tree_util.tree_map(lambda x: x[0], genotypes)
 
         # Prepare init optimizer states
         critic_optimizer_state = self._critic_optimizer.init(critic_params)
@@ -189,51 +185,52 @@ class QualityPGEmitter(Emitter):
             target_critic_params=target_critic_params,
             target_actor_params=target_actor_params,
             replay_buffer=replay_buffer,
-            key=key,
-            steps=jnp.array(0),
+            key=random_key,
         )
 
         return emitter_state
 
-    @partial(jax.jit, static_argnames=("self",))
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit(
         self,
-        repertoire: GARepertoire,
+        repertoire: Repertoire,
         emitter_state: QualityPGEmitterState,
-        key: RNGKey,
-    ) -> Tuple[Genotype, ExtraScores]:
+        random_key: RNGKey,
+    ) -> Tuple[Genotype, ExtraScores, RNGKey]:
         """Do a step of PG emission.
 
         Args:
             repertoire: the current repertoire of genotypes
             emitter_state: the state of the emitter used
-            key: a random key
+            random_key: a random key
 
         Returns:
-            A batch of offspring, the new emitter state.
+            A batch of offspring, the new emitter state and a new key.
         """
 
         batch_size = self._config.env_batch_size
 
         # sample parents
         mutation_pg_batch_size = int(batch_size - 1)
-        parents = repertoire.select(
-            key, mutation_pg_batch_size, selector=self._selector
-        ).genotypes
+        parents = repertoire.sample(random_key, mutation_pg_batch_size)
 
         # apply the pg mutation
+        random_key, subkey = jax.random.split(random_key)
+        emitter_state = emitter_state.replace(key=subkey)
         offsprings_pg = self.emit_pg(emitter_state, parents)
 
         # get the actor (greedy actor)
         offspring_actor = self.emit_actor(emitter_state)
 
         # add dimension for concatenation
-        offspring_actor = jax.tree.map(
+        offspring_actor = jax.tree_util.tree_map(
             lambda x: jnp.expand_dims(x, axis=0), offspring_actor
         )
-
         # gather offspring
-        genotypes = jax.tree.map(
+        genotypes = jax.tree_util.tree_map(
             lambda x, y: jnp.concatenate([x, y], axis=0),
             offsprings_pg,
             offspring_actor,
@@ -241,7 +238,11 @@ class QualityPGEmitter(Emitter):
 
         return genotypes, {}
 
-    @partial(jax.jit, static_argnames=("self",))
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_pg(
         self, emitter_state: QualityPGEmitterState, parents: Genotype
     ) -> Genotype:
@@ -256,15 +257,50 @@ class QualityPGEmitter(Emitter):
         Returns:
             A new set of offsprings.
         """
-        mutation_fn = partial(
-            self._mutation_function_pg,
-            emitter_state=emitter_state,
+
+        # create a batch of policy optimizer states
+        policy_opt_states = jax.vmap(self._policies_optimizer.init)(parents)
+
+        # prepare the batched policy update function with vmapping
+        batched_policy_update_fn = jax.vmap(
+            partial(self._update_policy, critic_params=emitter_state.critic_params),
+            in_axes=(0, 0, None),
         )
-        offsprings = jax.vmap(mutation_fn)(parents)
 
-        return offsprings
+        def scan_update_policies(
+            carry: Tuple[Params, optax.OptState, RNGKey],
+            _: None,
+        ) -> Tuple[Tuple[Params, optax.OptState, RNGKey], Any]:
 
-    @partial(jax.jit, static_argnames=("self",))
+            # Unpack the carry
+            (policy_params, policy_opt_state, key) = carry
+
+            # sample a mini-batch of data from the replay-buffer
+            transitions = emitter_state.replay_buffer.sample(
+                key, self._config.batch_size
+            )
+            (
+                new_policy_params,
+                new_policy_opt_states,
+            ) = batched_policy_update_fn(policy_params, policy_opt_state, transitions)
+            return (new_policy_params, new_policy_opt_states, key), ()
+
+        (
+            final_policy_params,
+            final_policy_opt_state,
+            final_key,
+        ), _ = jax.lax.scan(
+            scan_update_policies,
+            (parents, policy_opt_states, emitter_state.key),
+            length=self._config.num_pg_training_steps,
+        )
+
+        return final_policy_params
+
+    @partial(
+        jax.jit,
+        static_argnames=("self",),
+    )
     def emit_actor(self, emitter_state: QualityPGEmitterState) -> Genotype:
         """Emit the greedy actor.
 
@@ -315,137 +351,79 @@ class QualityPGEmitter(Emitter):
         transitions = extra_scores["transitions"]
 
         # add transitions in the replay buffer
-        replay_buffer = emitter_state.replay_buffer.insert(transitions)
-        emitter_state = emitter_state.replace(replay_buffer=replay_buffer)
-
-        def scan_train_critics(
-            carry: QualityPGEmitterState, _: Any
-        ) -> Tuple[QualityPGEmitterState, Any]:
-            emitter_state = carry
-            new_emitter_state = self._train_critics(emitter_state)
-            return new_emitter_state, ()
-
-        # Train critics and greedy actor
-        emitter_state, _ = jax.lax.scan(
-            scan_train_critics,
-            emitter_state,
-            (),
-            length=self._config.num_critic_training_steps,
+        emitter_state = emitter_state.replace(
+            replay_buffer=emitter_state.replay_buffer.insert(transitions)
         )
 
-        return emitter_state  # type: ignore
+        # Conduct Actor-Critic training
+        final_emitter_state, _ = jax.lax.scan(
+            self._scan_actor_critic_training,
+            emitter_state,
+            length=self._actor_critic_iterations,
+        )
+
+        return final_emitter_state  # type: ignore
 
     @partial(jax.jit, static_argnames=("self",))
-    def _train_critics(
-        self, emitter_state: QualityPGEmitterState
-    ) -> QualityPGEmitterState:
-        """Apply one gradient step to critics and to the greedy actor
-        (contained in carry in training_state), then soft update target critics
-        and target actor.
-
-        Those updates are very similar to those made in TD3.
+    def _scan_update_critic(
+        self,
+        carry: Tuple[Params, Params, optax.OptState, Params, RNGKey],
+        transitions: QDTransition,
+    ) -> Tuple[Tuple[Params, Params, optax.OptState, Params, RNGKey], Any]:
+        """A scan-ready function to update the critic network parameters
+        with one gradient step.
 
         Args:
-            emitter_state: actual emitter state
+            carry: packed carry containing critic parameters, target critic
+                parameters, critic optimiser state, target actor parameters,
+                and the random key.
+            transitions: a mini-batch of QDTransitions for gradient computation
 
         Returns:
-            New emitter state where the critic and the greedy actor have been
-            updated. Optimizer states have also been updated in the process.
+            new_carry: new carry containing updated parameters (target actor
+                parameters is unchanged).
+            empty tuple: compulsory signature for jax.lax.scan
         """
-        key = emitter_state.key
-
-        # Sample a batch of transitions in the buffer
-        key, subkey = jax.random.split(key)
-        replay_buffer = emitter_state.replay_buffer
-        transitions = replay_buffer.sample(subkey, sample_size=self._config.batch_size)
-
-        # Update Critic
-        key, subkey = jax.random.split(key)
+        # unpack the carry
         (
-            critic_optimizer_state,
             critic_params,
             target_critic_params,
-        ) = self._update_critic(
-            critic_params=emitter_state.critic_params,
-            target_critic_params=emitter_state.target_critic_params,
-            target_actor_params=emitter_state.target_actor_params,
-            critic_optimizer_state=emitter_state.critic_optimizer_state,
-            transitions=transitions,
-            key=subkey,
-        )
-
-        # Update greedy actor
-        (
-            actor_optimizer_state,
-            actor_params,
+            critic_opt_state,
             target_actor_params,
-        ) = jax.lax.cond(
-            emitter_state.steps % self._config.policy_delay == 0,
-            lambda x: self._update_actor(*x),
-            lambda _: (
-                emitter_state.actor_opt_state,
-                emitter_state.actor_params,
-                emitter_state.target_actor_params,
-            ),
-            operand=(
-                emitter_state.actor_params,
-                emitter_state.actor_opt_state,
-                emitter_state.target_actor_params,
-                emitter_state.critic_params,
-                transitions,
-            ),
-        )
+            key,
+        ) = carry
 
-        # Create new training state
-        new_emitter_state = emitter_state.replace(
-            critic_params=critic_params,
-            critic_optimizer_state=critic_optimizer_state,
-            actor_params=actor_params,
-            actor_opt_state=actor_optimizer_state,
-            target_critic_params=target_critic_params,
-            target_actor_params=target_actor_params,
-            key=key,
-            steps=emitter_state.steps + 1,
-            replay_buffer=replay_buffer,
-        )
-
-        return new_emitter_state  # type: ignore
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _update_critic(
-        self,
-        critic_params: Params,
-        target_critic_params: Params,
-        target_actor_params: Params,
-        critic_optimizer_state: Params,
-        transitions: QDTransition,
-        key: RNGKey,
-    ) -> Tuple[Params, Params, Params]:
-
-        # compute loss and gradients
+        # compute the critic gradients
+        key, subkey = jax.random.split(key)
         critic_gradient = jax.grad(self._critic_loss_fn)(
             critic_params,
             target_actor_params,
             target_critic_params,
             transitions,
-            key,
+            subkey,
         )
-        critic_updates, critic_optimizer_state = self._critic_optimizer.update(
-            critic_gradient, critic_optimizer_state
-        )
-
         # update critic
-        critic_params = optax.apply_updates(critic_params, critic_updates)
+        critic_updates, new_critic_opt_state = self._critic_optimizer.update(
+            critic_gradient, critic_opt_state
+        )
+        new_critic_params = optax.apply_updates(critic_params, critic_updates)
 
         # Soft update of target critic network
-        target_critic_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_critic_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_critic_params,
-            critic_params,
+            new_critic_params,
         )
-
-        return critic_optimizer_state, critic_params, target_critic_params
+        # pack into new carry
+        new_carry = (
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
+        )
+        return new_carry, ()
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_actor(
@@ -456,6 +434,22 @@ class QualityPGEmitter(Emitter):
         critic_params: Params,
         transitions: QDTransition,
     ) -> Tuple[optax.OptState, Params, Params]:
+        """Function to update the actor with one Policy-Gradient step.
+
+        Args:
+            actor_params: neural network parameters of the actor.
+            actor_opt_state: optimiser state of the actor.
+            target_actor_params: target actor parameters (used in TD3 to
+                smooth the actor-critic learning).
+            critic_params: the parameters of the critic networks which plays
+                as a differentiable target.
+            transitions: a mini-batch of QDTransitions.
+
+        Returns:
+            new_actor_params: new actor parameters after taking the PG step
+            new_target_actor_params: new target actor parameters (soft-tau update)
+            new_actor_opt_state: updated optimiser state
+        """
 
         # Update greedy actor
         policy_gradient = jax.grad(self._policy_loss_fn)(
@@ -465,140 +459,139 @@ class QualityPGEmitter(Emitter):
         )
         (
             policy_updates,
-            actor_optimizer_state,
+            new_actor_opt_state,
         ) = self._actor_optimizer.update(policy_gradient, actor_opt_state)
-        actor_params = optax.apply_updates(actor_params, policy_updates)
+        new_actor_params = optax.apply_updates(actor_params, policy_updates)
 
         # Soft update of target greedy actor
-        target_actor_params = jax.tree.map(
-            lambda x1, x2: (1.0 - self._config.soft_tau_update) * x1
-            + self._config.soft_tau_update * x2,
+        new_target_actor_params = jax.tree.map(
+            lambda x, y: (1.0 - self._config.soft_tau_update) * x
+            + self._config.soft_tau_update * y,
             target_actor_params,
-            actor_params,
+            new_actor_params,
         )
 
-        return (
-            actor_optimizer_state,
-            actor_params,
-            target_actor_params,
-        )
+        return new_actor_params, new_target_actor_params, new_actor_opt_state
 
     @partial(jax.jit, static_argnames=("self",))
-    def _mutation_function_pg(
-        self,
-        policy_params: Genotype,
-        emitter_state: QualityPGEmitterState,
-    ) -> Genotype:
-        """Apply pg mutation to a policy via multiple steps of gradient descent.
-        First, update the rewards to be diversity rewards, then apply the gradient
-        steps.
+    def _scan_actor_critic_training(
+        self, carry: QualityPGEmitterState, _: None
+    ) -> Tuple[QualityPGEmitterState, Tuple]:
+        """
+        Perform a few (policy delay) steps of critic followed by one step of
+        actor training, all packed into a single scan-ready function.
+        Transition data are sampled step-by-step to promote memory efficiency.
 
         Args:
-            policy_params: a policy, supposed to be a differentiable neural
-                network.
-            emitter_state: the current state of the emitter, containing among others,
-                the replay buffer, the critic.
+            carry: emitter state
+            _: None
 
         Returns:
-            The updated params of the neural network.
+            new_emitter_state: new emitter state containing updated network
+                parameters as the new carry.
+            empty tuple: compulsory signature for jax.lax.scan
         """
 
-        # Define new policy optimizer state
-        policy_optimizer_state = self._policies_optimizer.init(policy_params)
-
-        def scan_train_policy(
-            carry: Tuple[QualityPGEmitterState, Genotype, optax.OptState],
-            _: Any,
-        ) -> Tuple[Tuple[QualityPGEmitterState, Genotype, optax.OptState], Any]:
-            emitter_state, policy_params, policy_optimizer_state = carry
-            (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_optimizer_state,
-            ) = self._train_policy(
-                emitter_state,
-                policy_params,
-                policy_optimizer_state,
-            )
-            return (
-                new_emitter_state,
-                new_policy_params,
-                new_policy_optimizer_state,
-            ), ()
-
-        (
-            emitter_state,
-            policy_params,
-            policy_optimizer_state,
-        ), _ = jax.lax.scan(
-            scan_train_policy,
-            (emitter_state, policy_params, policy_optimizer_state),
-            (),
-            length=self._config.num_pg_training_steps,
-        )
-
-        return policy_params
-
-    @partial(jax.jit, static_argnames=("self",))
-    def _train_policy(
-        self,
-        emitter_state: QualityPGEmitterState,
-        policy_params: Params,
-        policy_optimizer_state: optax.OptState,
-    ) -> Tuple[QualityPGEmitterState, Params, optax.OptState]:
-        """Apply one gradient step to a policy (called policy_params).
-
-        Args:
-            emitter_state: current state of the emitter.
-            policy_params: parameters corresponding to the weights and bias of
-                the neural network that defines the policy.
-
-        Returns:
-            The new emitter state and new params of the NN.
-        """
+        emitter_state = carry
         key = emitter_state.key
 
-        # Sample a batch of transitions in the buffer
-        key, subkey = jax.random.split(key)
-        replay_buffer = emitter_state.replay_buffer
-        transitions = replay_buffer.sample(subkey, sample_size=self._config.batch_size)
-
-        # update policy
-        policy_optimizer_state, policy_params = self._update_policy(
-            critic_params=emitter_state.critic_params,
-            policy_optimizer_state=policy_optimizer_state,
-            policy_params=policy_params,
-            transitions=transitions,
+        # sample transitions
+        transitions = emitter_state.replay_buffer.sample(
+            key,
+            self._config.batch_size * (self._config.policy_delay + 1),
         )
+        transitions = jax.tree.map(
+            lambda x: jnp.reshape(
+                x,
+                (
+                    self._config.policy_delay + 1,
+                    self._config.batch_size,
+                    *x.shape[1:],
+                ),
+            ),
+            transitions,
+        )
+        # split the transitions for critic and actor
+        critic_data = jax.tree.map(lambda x: x[:-1], transitions)
+        actor_data = jax.tree.map(lambda x: x[-1], transitions)
 
-        # Create new training state
+        # scan training critics
+        (
+            new_critic_params,
+            new_target_critic_params,
+            new_critic_opt_state,
+            target_actor_params,
+            key,
+        ), () = jax.lax.scan(
+            self._scan_update_critic,
+            (
+                emitter_state.critic_params,
+                emitter_state.target_critic_params,
+                emitter_state.critic_optimizer_state,
+                emitter_state.target_actor_params,
+                key,
+            ),
+            critic_data,
+        )
+        # update the actor with one gradient step
+        (new_actor_params, new_target_actor_params, new_actor_opt_state) = (
+            self._update_actor(
+                emitter_state.actor_params,
+                emitter_state.actor_opt_state,
+                target_actor_params,
+                new_critic_params,
+                actor_data,
+            )
+        )
         new_emitter_state = emitter_state.replace(
+            critic_params=new_critic_params,
+            critic_optimizer_state=new_critic_opt_state,
+            actor_params=new_actor_params,
+            actor_opt_state=new_actor_opt_state,
+            target_critic_params=new_target_critic_params,
+            target_actor_params=new_target_actor_params,
             key=key,
-            replay_buffer=replay_buffer,
         )
 
-        return new_emitter_state, policy_params, policy_optimizer_state
+        return new_emitter_state, ()
+
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(
         self,
-        critic_params: Params,
-        policy_optimizer_state: optax.OptState,
         policy_params: Params,
+        policy_opt_state: optax.OptState,
         transitions: QDTransition,
+        critic_params: Params,
     ) -> Tuple[optax.OptState, Params]:
+        """
+        Perform one step of PG update on the off-spring policy.
+        This function is vmapped to mutate the entire batch of off-springs
+        in parallel.
 
-        # compute loss
+        Args:
+            policy_params: the parameters of the policy.
+            policy_opt_state: the optimiser state of the policy.
+            transitions: a mini-batch of transitions for gradient computation
+            critic_params: the parameters of the critic networks serving as
+                a differentiable target. This is fixed in each iteration.
+
+        Returns:
+            new_policy_params: new policy parameters
+            new_policy_opt_state: updated optimiser state
+        """
+
+        # Compute the policy gradient
         policy_gradient = jax.grad(self._policy_loss_fn)(
             policy_params,
             critic_params,
             transitions,
         )
-        # Compute gradient and update policies
+        # Apply the update on the policy
         (
             policy_updates,
-            policy_optimizer_state,
-        ) = self._policies_optimizer.update(policy_gradient, policy_optimizer_state)
-        policy_params = optax.apply_updates(policy_params, policy_updates)
+            new_policy_opt_state,
+        ) = self._policies_optimizer.update(policy_gradient, policy_opt_state)
+        new_policy_params = optax.apply_updates(policy_params, policy_updates)
 
-        return policy_optimizer_state, policy_params
+        return new_policy_params, new_policy_opt_state

--- a/qdax/core/emitters/qpg_emitter.py
+++ b/qdax/core/emitters/qpg_emitter.py
@@ -13,15 +13,13 @@ import optax
 from jax import numpy as jnp
 
 from qdax.core.containers.repertoire import Repertoire
-from qdax.core.emitters.repertoire_selectors.selector import Selector
 from qdax.core.emitters.emitter import Emitter, EmitterState
+from qdax.core.emitters.repertoire_selectors.selector import Selector
 from qdax.core.neuroevolution.buffers.buffer import QDTransition, ReplayBuffer
 from qdax.core.neuroevolution.losses.td3_loss import make_td3_loss_fn
 from qdax.core.neuroevolution.networks.networks import QModule
 from qdax.custom_types import Descriptor, ExtraScores, Fitness, Genotype, Params, RNGKey
 from qdax.environments.base_wrappers import QDEnv
-
-
 
 
 @dataclass
@@ -106,7 +104,6 @@ class QualityPGEmitter(Emitter):
         self._policies_optimizer = optax.adam(
             learning_rate=self._config.policy_learning_rate
         )
-
 
     @property
     def batch_size(self) -> int:
@@ -223,7 +220,7 @@ class QualityPGEmitter(Emitter):
         mutation_pg_batch_size = int(batch_size - 1)
         parents = repertoire.select(
             key, mutation_pg_batch_size, selector=self._selector
-            ).genotypes
+        ).genotypes
 
         # apply the pg mutation
         offsprings_pg = self.emit_pg(emitter_state, parents)
@@ -243,7 +240,6 @@ class QualityPGEmitter(Emitter):
         )
 
         return genotypes, {}
-
 
     @partial(
         jax.jit,
@@ -369,7 +365,6 @@ class QualityPGEmitter(Emitter):
         )
 
         return final_emitter_state  # type: ignore
-
 
     @partial(jax.jit, static_argnames=("self",))
     def _scan_update_critic(
@@ -561,7 +556,6 @@ class QualityPGEmitter(Emitter):
         )
 
         return new_emitter_state, ()
-
 
     @partial(jax.jit, static_argnames=("self",))
     def _update_policy(

--- a/qdax/core/emitters/qpg_emitter.py
+++ b/qdax/core/emitters/qpg_emitter.py
@@ -24,8 +24,6 @@ from qdax.environments.base_wrappers import QDEnv
 
 
 
-
-
 @dataclass
 class QualityPGConfig:
     """Configuration for QualityPG Emitter"""

--- a/qdax/core/emitters/qpg_emitter.py
+++ b/qdax/core/emitters/qpg_emitter.py
@@ -133,7 +133,7 @@ class QualityPGEmitter(Emitter):
         fitnesses: Fitness,
         descriptors: Descriptor,
         extra_scores: ExtraScores,
-    ) -> Tuple[QualityPGEmitterState, RNGKey]:
+    ) -> QualityPGEmitterState:
         """Initializes the emitter state.
 
         Args:
@@ -205,7 +205,7 @@ class QualityPGEmitter(Emitter):
         repertoire: Repertoire,
         emitter_state: QualityPGEmitterState,
         key: RNGKey,
-    ) -> Tuple[Genotype, ExtraScores, RNGKey]:
+    ) -> Tuple[Genotype, ExtraScores]:
         """Do a step of PG emission.
 
         Args:
@@ -361,7 +361,6 @@ class QualityPGEmitter(Emitter):
         emitter_state = emitter_state.replace(
             replay_buffer=emitter_state.replay_buffer.insert(transitions)
         )
-
         # Conduct Actor-Critic training
         final_emitter_state, _ = jax.lax.scan(
             self._scan_actor_critic_training,
@@ -370,6 +369,7 @@ class QualityPGEmitter(Emitter):
         )
 
         return final_emitter_state  # type: ignore
+
 
     @partial(jax.jit, static_argnames=("self",))
     def _scan_update_critic(

--- a/qdax/core/neuroevolution/losses/td3_loss.py
+++ b/qdax/core/neuroevolution/losses/td3_loss.py
@@ -102,7 +102,7 @@ def make_td3_loss_dc_fn(
     noise_clip: float,
     policy_noise: float,
 ) -> Tuple[
-    Callable[[Params, Params, Transition], jnp.ndarray],
+    Callable[[Params, Params, Descriptor, Transition], jnp.ndarray],
     Callable[[Params, Params, Transition], jnp.ndarray],
     Callable[[Params, Params, Params, Transition, RNGKey], jnp.ndarray],
 ]:
@@ -125,7 +125,7 @@ def make_td3_loss_dc_fn(
     def _policy_loss_fn(
         policy_params: Params,
         critic_params: Params,
-        desc_prime: jnp.ndarray,
+        desc_prime: Descriptor,
         transitions: Transition,
     ) -> jnp.ndarray:
         """Policy loss function for TD3 agent"""
@@ -156,12 +156,11 @@ def make_td3_loss_dc_fn(
         target_actor_params: Params,
         target_critic_params: Params,
         transitions: Transition,
-        random_key: RNGKey,
+        key: RNGKey,
     ) -> jnp.ndarray:
         """Descriptor-conditioned critic loss function for TD3 agent"""
         noise = (
-            jax.random.normal(random_key, shape=transitions.actions.shape)
-            * policy_noise
+            jax.random.normal(key, shape=transitions.actions.shape) * policy_noise
         ).clip(-noise_clip, noise_clip)
 
         next_action = (

--- a/qdax/core/neuroevolution/losses/td3_loss.py
+++ b/qdax/core/neuroevolution/losses/td3_loss.py
@@ -283,4 +283,3 @@ def td3_critic_loss_fn(
     q_loss = jnp.sum(q_losses, axis=-1)
 
     return q_loss
-


### PR DESCRIPTION
Related issues: PGA and DCRL: duplicated sampling of transitions in "emit_pg", unnecessary occupation of Vram in "state_update", too complicated structure of functions.


This PR introduces:
- Off-springs performing PG mutation now share the same mini-batch of data in emit_pg. 
- Sampling of transitions in both "emit_pg" and "state_update" is now made step by step. 
- "policy_loss" in "make_td3_dc_loss" now take desc_prime from the input instead of from transitions (so that transition can be shared) .
- Function "mutate_function_pg" is simplified and emerged into "emit_pg".
- Combined "train_xxxx" and "update_xxxx" into a single function.
- Build a new function "scan_actor_critic_training" for Actor-Critic training loop.
- Removed meaningless similarity (and novelty) calculation in dcrl_emitter (and in dpg_emitter).
- dpg_emitter modified accordingly.


## Checks
 
- [x] a clear description of the PR has been added
- [x] sufficient tests have been written
- [x] example notebook have been added to the repo
- [x] all example notebooks have been verified to execute without errors
- [x] clean docstrings and comments have been written
- [ ] relevant section have been added to the documentation
- [x] if any issue/observation has been discovered, a new issue has been opened
- [x] the source branch is `develop` if this PR introduces a new feature

## Benchmark Test Results

All updated emitters have been tested with corresponding example Jupyter notebooks. No error or loss of performance observed.

DCRL (Ant_omni,  128 GA + 64 PG + 64 AI)
New version (11min16s):
![new_dcrl_ant_omni_(11min30s)](https://github.com/user-attachments/assets/0e0228eb-70e8-4be6-8672-5c2898830499)
Old version (11min23s):
![old_dcrl_ant_omni_(11min23s)](https://github.com/user-attachments/assets/6174d4c4-397e-4722-8fe9-6c61795002ef)


DCRL (Walker2d, 128 GA + 64 PG + 64 AI)
New version (12min32s):
![new_dcrl_walker_(12min32s)](https://github.com/user-attachments/assets/66fc84f1-102e-44fa-b921-3d25f55e1506)
Old version (12mins45s):
![old_dcrl_walker_(12min45s)](https://github.com/user-attachments/assets/4292710e-bc6e-4813-aff8-0cab74368211)


PGA (Ant_omni, 64 GA + 63 PG + 1 AI)
New version (12min44s):
![new_pga_ant_omni_(12min44s)](https://github.com/user-attachments/assets/3f624ae7-50cb-40c7-baa2-4ef745b7d6ed)
Old version (13min07s):
![old_pga_ant_omni_(13min07s)](https://github.com/user-attachments/assets/d9e4ef9d-f7e1-48a8-8b05-c1e353f0c2fb)



PGA (Walker2d, 64 GA + 63 PG + 1 AI)
New version (14min06s):
![new_pga_walker_(14min6s)](https://github.com/user-attachments/assets/add4c791-e074-4745-9e34-715292fd8ffa)
Old version (14min31s):
![old_pga_walker_(14min31s)](https://github.com/user-attachments/assets/cf0be4e4-6b65-44f7-b089-b2b1b059d076)


QDPG is super slow (5 seconds each iteration), main bottle-neck is the diversity archive insertion. Benchmark excluded.

All tests done with 1000 iterations, minibatch size 256, 150 PG mutation steps, 3000 critic training steps, 2 for policy delay, and seed 42. Ant_omni takes 250 time-steps and walker takes 1000.

## Future improvements
 
DPG and QPG in QDPG use two but actually duplicated replay-buffers, which can be merged into a single one to save several GiBs of Vram. Advise optimize runtime performance for diversity archive insertion, which is taking 80% of the time.