### PR TITLE
Feat: remove save and load methods

### DIFF
--- a/examples/aurora.ipynb
+++ b/examples/aurora.ipynb
@@ -21,8 +21,7 @@
     "- how to create an AURORA instance\n",
     "- which functions must be defined before training\n",
     "- how to launch a certain number of training steps\n",
-    "- how to visualise the optimization process\n",
-    "- how to save/load a repertoire"
+    "- how to visualise the optimization process"
    ]
   },
   {

--- a/examples/mapelites.ipynb
+++ b/examples/mapelites.ipynb
@@ -21,8 +21,7 @@
     "- how to create a Map-elites instance\n",
     "- which functions must be defined before training\n",
     "- how to launch a certain number of training steps\n",
-    "- how to visualise the optimization process\n",
-    "- how to save/load a repertoire"
+    "- how to visualise the optimization process"
    ]
   },
   {
@@ -369,77 +368,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# How to save/load a repertoire\n",
-    "\n",
-    "The following cells show how to save or load a repertoire of individuals and add a few lines to visualise the best performing individual in a simulation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Load the final repertoire"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "repertoire_path = \"./last_repertoire/\"\n",
-    "os.makedirs(repertoire_path, exist_ok=True)\n",
-    "repertoire.save(path=repertoire_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Build the reconstruction function"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Init population of policies\n",
-    "key, subkey = jax.random.split(key)\n",
-    "fake_batch = jnp.zeros(shape=(env.observation_size,))\n",
-    "fake_params = policy_network.init(subkey, fake_batch)\n",
-    "\n",
-    "_, reconstruction_fn = ravel_pytree(fake_params)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Use the reconstruction function to load and re-create the repertoire"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "repertoire = MapElitesRepertoire.load(reconstruction_fn=reconstruction_fn, path=repertoire_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Get the best individual of the repertoire"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -469,6 +397,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# select the parameters of the best individual\n",
     "my_params = jax.tree.map(\n",
     "    lambda x: x[best_idx],\n",
     "    repertoire.genotypes\n",

--- a/examples/mapelites_asktell.ipynb
+++ b/examples/mapelites_asktell.ipynb
@@ -21,8 +21,7 @@
     "- how to create a Map-elites instance\n",
     "- which functions must be defined before training\n",
     "- how to launch a certain number of training steps\n",
-    "- how to visualise the optimization process\n",
-    "- how to save/load a repertoire"
+    "- how to visualise the optimization process"
    ]
   },
   {

--- a/examples/mels.ipynb
+++ b/examples/mels.ipynb
@@ -20,8 +20,7 @@
     "- how to create an ME-LS instance\n",
     "- which functions must be defined before training\n",
     "- how to launch a certain number of training steps\n",
-    "- how to visualise the optimization process\n",
-    "- how to save/load a repertoire"
+    "- how to visualise the optimization process"
    ]
   },
   {
@@ -387,70 +386,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# How to save/load a repertoire\n",
-    "\n",
-    "The following cells show how to save or load a repertoire of individuals and add a few lines to visualise the best performing individual in a simulation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Load the final repertoire"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "repertoire_path = \"./last_repertoire/\"\n",
-    "os.makedirs(repertoire_path, exist_ok=True)\n",
-    "repertoire.save(path=repertoire_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Build the reconstruction function"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Init population of policies\n",
-    "key, subkey = jax.random.split(key)\n",
-    "fake_batch = jnp.zeros(shape=(env.observation_size,))\n",
-    "fake_params = policy_network.init(subkey, fake_batch)\n",
-    "\n",
-    "_, reconstruction_fn = ravel_pytree(fake_params)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Use the reconstruction function to load and re-create the repertoire"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "repertoire = MELSRepertoire.load(reconstruction_fn=reconstruction_fn, path=repertoire_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Get the best individual of the repertoire\n",
     "\n",
     "Note that in ME-LS, the individual's cell is computed by finding its most frequent archive cell among its `num_samples` descriptors. Thus, the descriptor associated with each individual in the archive is not its mean descriptor. Rather, we set the descriptor in the archive to be the centroid of the individual's most frequent archive cell."
@@ -488,6 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# select the parameters of the best individual\n",
     "my_params = jax.tree.map(\n",
     "    lambda x: x[best_idx],\n",
     "    repertoire.genotypes\n",

--- a/examples/pga_aurora.ipynb
+++ b/examples/pga_aurora.ipynb
@@ -21,8 +21,7 @@
     "- how to create an AURORA instance and mix it with the right emitter to define PGA-AURORA\n",
     "- which functions must be defined before training\n",
     "- how to launch a certain number of training steps\n",
-    "- how to visualise the optimization process\n",
-    "- how to save/load a repertoire"
+    "- how to visualise the optimization process"
    ]
   },
   {
@@ -420,8 +419,6 @@
     "    model, subkey, (1, *observations_dims)\n",
     ")\n",
     "\n",
-    "print(jax.tree_map(lambda x: x.shape, model_params))\n",
-    "\n",
     "# Define the encoder function\n",
     "encoder_fn = jax.jit(\n",
     "    functools.partial(\n",
@@ -451,8 +448,6 @@
     "model_params = train_seq2seq.get_initial_params(\n",
     "    model, subkey, (1, *observations_dims)\n",
     ")\n",
-    "\n",
-    "print(jax.tree_map(lambda x: x.shape, model_params))\n",
     "\n",
     "# define arbitrary observation's mean/std\n",
     "mean_observations = jnp.zeros(observations_dims[-1])\n",

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,3 @@ strict_equality = True
 explicit_package_bases = True
 follow_imports = skip
 ignore_missing_imports = True
-
-[mypy-tensorflow_probability.*]
-ignore_missing_imports = True

--- a/qdax/core/containers/ga_repertoire.py
+++ b/qdax/core/containers/ga_repertoire.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
-from jax.flatten_util import ravel_pytree
 
 from qdax.core.containers.repertoire import Repertoire
 from qdax.core.emitters.repertoire_selectors.selector import GARepertoireT, Selector
@@ -37,46 +36,6 @@ class GARepertoire(Repertoire):
         """Gives the size of the population."""
         first_leaf = jax.tree.leaves(self.genotypes)[0]
         return int(first_leaf.shape[0])
-
-    def save(self, path: str = "./") -> None:
-        """Saves the repertoire.
-
-        Args:
-            path: place to store the files. Defaults to "./".
-        """
-
-        def flatten_genotype(genotype: Genotype) -> jnp.ndarray:
-            flatten_genotype, _ = ravel_pytree(genotype)
-            return flatten_genotype
-
-        # flatten all the genotypes
-        flat_genotypes = jax.vmap(flatten_genotype)(self.genotypes)
-
-        jnp.save(path + "genotypes.npy", flat_genotypes)
-        jnp.save(path + "scores.npy", self.fitnesses)
-
-    @classmethod
-    def load(cls, reconstruction_fn: Callable, path: str = "./") -> GARepertoire:
-        """Loads a GA Repertoire.
-
-        Args:
-            reconstruction_fn: Function to reconstruct a PyTree
-                from a flat array.
-            path: Path where the data is saved. Defaults to "./".
-
-        Returns:
-            A GA Repertoire.
-        """
-
-        flat_genotypes = jnp.load(path + "genotypes.npy")
-        genotypes = jax.vmap(reconstruction_fn)(flat_genotypes)
-
-        fitnesses = jnp.load(path + "fitnesses.npy")
-
-        return cls(
-            genotypes=genotypes,
-            fitnesses=fitnesses,
-        )
 
     def select(
         self,

--- a/qdax/core/containers/mapelites_repertoire.py
+++ b/qdax/core/containers/mapelites_repertoire.py
@@ -5,11 +5,10 @@ algorithm as well as several variants."""
 from __future__ import annotations
 
 import warnings
-from typing import Callable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
-from jax.flatten_util import ravel_pytree
 from numpy.random import RandomState
 from sklearn.cluster import KMeans
 
@@ -161,30 +160,6 @@ class MapElitesRepertoire(GARepertoire):
     descriptors: Descriptor
     centroids: Centroid
 
-    def save(self, path: str = "./") -> None:
-        """Saves the repertoire on disk in the form of .npy files.
-
-        Flattens the genotypes to store it with .npy format. Supposes that
-        a user will have access to the reconstruction function when loading
-        the genotypes.
-
-        Args:
-            path: Path where the data will be saved. Defaults to "./".
-        """
-
-        def flatten_genotype(genotype: Genotype) -> jnp.ndarray:
-            flatten_genotype, _ = ravel_pytree(genotype)
-            return flatten_genotype
-
-        # flatten all the genotypes
-        flat_genotypes = jax.vmap(flatten_genotype)(self.genotypes)
-
-        # save data
-        jnp.save(path + "genotypes.npy", flat_genotypes)
-        jnp.save(path + "fitnesses.npy", self.fitnesses)
-        jnp.save(path + "descriptors.npy", self.descriptors)
-        jnp.save(path + "centroids.npy", self.centroids)
-
     def select(
         self,
         key: RNGKey,
@@ -195,33 +170,6 @@ class MapElitesRepertoire(GARepertoire):
             selector = UniformSelector(select_with_replacement=True)
         repertoire = selector.select(self, key, num_samples)
         return repertoire
-
-    @classmethod
-    def load(cls, reconstruction_fn: Callable, path: str = "./") -> MapElitesRepertoire:
-        """Loads a MAP Elites Repertoire.
-
-        Args:
-            reconstruction_fn: Function to reconstruct a PyTree
-                from a flat array.
-            path: Path where the data is saved. Defaults to "./".
-
-        Returns:
-            A MAP Elites Repertoire.
-        """
-
-        flat_genotypes = jnp.load(path + "genotypes.npy")
-        genotypes = jax.vmap(reconstruction_fn)(flat_genotypes)
-
-        fitnesses = jnp.load(path + "fitnesses.npy")
-        descriptors = jnp.load(path + "descriptors.npy")
-        centroids = jnp.load(path + "centroids.npy")
-
-        return cls(
-            genotypes=genotypes,
-            fitnesses=fitnesses,
-            descriptors=descriptors,
-            centroids=centroids,
-        )
 
     @jax.jit
     def add(

--- a/qdax/core/containers/mels_repertoire.py
+++ b/qdax/core/containers/mels_repertoire.py
@@ -4,11 +4,10 @@ well as several variants."""
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
-from jax.flatten_util import ravel_pytree
 
 from qdax.core.containers.mapelites_repertoire import (
     MapElitesRepertoire,
@@ -63,7 +62,7 @@ class MELSRepertoire(MapElitesRepertoire):
 
     This class inherits from MapElitesRepertoire. In addition to the stored data in
     MapElitesRepertoire (genotypes, fitnesses, descriptors, centroids), this repertoire
-    also maintains an array of spreads. We overload the save, load, add, and
+    also maintains an array of spreads. We overload the add, and
     init_default methods of MapElitesRepertoire.
 
     Refer to Mace 2023 for more info on MAP-Elites Low-Spread:
@@ -86,60 +85,6 @@ class MELSRepertoire(MapElitesRepertoire):
     """
 
     spreads: Spread
-
-    def save(self, path: str = "./") -> None:
-        """Saves the repertoire on disk in the form of .npy files.
-
-        Flattens the genotypes to store it with .npy format. Supposes that
-        a user will have access to the reconstruction function when loading
-        the genotypes.
-
-        Args:
-            path: Path where the data will be saved. Defaults to "./".
-        """
-
-        def flatten_genotype(genotype: Genotype) -> jnp.ndarray:
-            flatten_genotype, _ = ravel_pytree(genotype)
-            return flatten_genotype
-
-        # flatten all the genotypes
-        flat_genotypes = jax.vmap(flatten_genotype)(self.genotypes)
-
-        # save data
-        jnp.save(path + "genotypes.npy", flat_genotypes)
-        jnp.save(path + "fitnesses.npy", self.fitnesses)
-        jnp.save(path + "descriptors.npy", self.descriptors)
-        jnp.save(path + "centroids.npy", self.centroids)
-        jnp.save(path + "spreads.npy", self.spreads)
-
-    @classmethod
-    def load(cls, reconstruction_fn: Callable, path: str = "./") -> MELSRepertoire:
-        """Loads a MAP-Elites Low-Spread Repertoire.
-
-        Args:
-            reconstruction_fn: Function to reconstruct a PyTree
-                from a flat array.
-            path: Path where the data is saved. Defaults to "./".
-
-        Returns:
-            A MAP-Elites Low-Spread Repertoire.
-        """
-
-        flat_genotypes = jnp.load(path + "genotypes.npy")
-        genotypes = jax.vmap(reconstruction_fn)(flat_genotypes)
-
-        fitnesses = jnp.load(path + "fitnesses.npy")
-        descriptors = jnp.load(path + "descriptors.npy")
-        centroids = jnp.load(path + "centroids.npy")
-        spreads = jnp.load(path + "spreads.npy")
-
-        return cls(
-            genotypes=genotypes,
-            fitnesses=fitnesses,
-            descriptors=descriptors,
-            centroids=centroids,
-            spreads=spreads,
-        )
 
     @jax.jit
     def add(

--- a/qdax/core/containers/mome_repertoire.py
+++ b/qdax/core/containers/mome_repertoire.py
@@ -47,8 +47,6 @@ class MOMERepertoire(MapElitesRepertoire):
 
     The shape of descriptors and centroids are:
     (num_centroids, num_descriptors, pareto_front_length).
-
-    Inherited functions: save and load.
     """
 
     @property


### PR DESCRIPTION
Related issues: N/A

Removing `save` and `load` methods from `MapElitesRepertoire` and children classes, as they were tiresome to maintain and implement for new types of repertoires. 

Instead, users can use their own custom way to save and load repertoire, such as `pickle` and `orbax`.

## Checks

- [x] a clear description of the PR has been added
- N/A sufficient tests have been written
- N/A example notebook have been added to the repo
- [ ] all example notebooks have been verified to execute without errors
- N/A clean docstrings and comments have been written
- N/A relevant section have been added to the documentation
- N/A if any issue/observation has been discovered, a new issue has been opened
- [x] the source branch is `develop` if this PR introduces a new feature

## Future improvements

N/A
